### PR TITLE
Add Forgot Password page with mock service and form validation

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -13,6 +13,11 @@ export const routes: Routes = [
         loadComponent: () => import('./features/signup/signup').then((c) => c.Signup),
       },
       { path: 'login', loadComponent: () => import('./features/login/login').then((c) => c.Login) },
+      {
+        path: 'forgot-password',
+        loadComponent: () =>
+          import('./features/forgot-password/forgot-password').then((c) => c.ForgotPassword),
+      },
     ],
   },
 

--- a/src/app/features/forgot-password/forgot-password.html
+++ b/src/app/features/forgot-password/forgot-password.html
@@ -1,12 +1,12 @@
 <div class="onboarding-login">
 
-  <!-- implementation of the toaster component later -->
+ 
 
 
   <h1>Forgot Password?</h1>
   <p>No worries! We'll help you reset it.</p>
 
-  <form [formGroup]="loginForm" (ngSubmit)="login()" novalidate>
+  <form [formGroup]="forgotPasswordForm" (ngSubmit)="login()" novalidate>
     <app-input-field
       label="Email"
       type="email"
@@ -18,7 +18,7 @@
 
     
 
-    <button class="login-button" type="submit" [disabled]="loginForm.invalid || loading">
+    <button class="login-button" type="submit" [disabled]="forgotPasswordForm.invalid || loading">
       {{ loading ? 'Sending Link...' : 'Send Link' }}
     </button>
   </form>

--- a/src/app/features/forgot-password/forgot-password.html
+++ b/src/app/features/forgot-password/forgot-password.html
@@ -1,0 +1,31 @@
+<div class="onboarding-login">
+
+  <!-- implementation of the toaster component later -->
+
+
+  <h1>Forgot Password?</h1>
+  <p>No worries! We'll help you reset it.</p>
+
+  <form [formGroup]="loginForm" (ngSubmit)="login()" novalidate>
+    <app-input-field
+      label="Email"
+      type="email"
+      id="email"
+      placeholder="Email"
+      [control]="getControl('email')"
+    ></app-input-field>
+
+
+    
+
+    <button class="login-button" type="submit" [disabled]="loginForm.invalid || loading">
+      {{ loading ? 'Sending Link...' : 'Send Link' }}
+    </button>
+  </form>
+
+  <div class="resend-and-retry">
+        <button>Resend email</button> or <button (click)="trydifferentemail()">Try a different email</button>
+    </div>
+
+
+</div>

--- a/src/app/features/forgot-password/forgot-password.scss
+++ b/src/app/features/forgot-password/forgot-password.scss
@@ -1,0 +1,167 @@
+@use 'mixins' as *;
+@use 'colors' as *;
+@use 'typography' as *;
+@use 'components' as *;
+
+.onboarding-login {
+  @include flex-column;
+  width: 100%;
+
+  h1 {
+    @include h9;
+    height: 36px;
+    margin-bottom: 8px;
+
+    @media screen and (min-width: 768px) {
+      @include h7;
+      height: 44px;
+      margin-bottom: 12px;
+    }
+
+    @media screen and (min-width: 1024px) {
+      @include h6;
+      height: 48px;
+      margin-bottom: 16px;
+    }
+  }
+  p {
+    @include h13;
+    color: $gray-text-strong;
+  }
+
+  form {
+    @include flex-column;
+    gap: 16px;
+    margin-top: 24px;
+    margin-bottom: 24px;
+
+    .error-message {
+      color: #e74c3c;
+      font-size: 0.8rem;
+      margin-top: 4px;
+    }
+
+    .login-input--group {
+      @include base-field;
+    }
+
+    .login-inputgroup-password {
+      label {
+        @include h13;
+        color: $gray-text-strong;
+      }
+      .input-password {
+        @include h12;
+        background-color: transparent;
+        color: $gray-stroke-strong;
+        border: 1px solid $gray-stroke-strong;
+        padding: 16px 12px;
+        border-radius: 4px;
+        overflow: hidden;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+
+        input {
+          border: none;
+          outline: none;
+          width: 90%;
+          background-color: transparent;
+          color: $gray-stroke-strong;
+          @include h12;
+        }
+
+        .password-toggle {
+          background: none;
+          border: none;
+          cursor: pointer;
+          color: $gray-stroke-strong;
+          font-size: 1.2rem;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+      }
+    }
+
+    .login-button {
+      @include button-primary;
+      margin-top: 8px;
+      @include h9;
+    }
+  }
+
+  .resend-and-retry {
+    @include h13;
+
+    button {
+      background: none;
+      border: none;
+      color: $brand-text;
+      cursor: pointer;
+      padding: 0;
+      @include h13;
+    }
+  }
+
+  .login-or {
+    @include h9;
+    text-align: center;
+    padding-block: 15px;
+    color: $gray-text-strong;
+  }
+
+  a {
+    @include h9;
+    text-decoration: none;
+    color: $brand-text;
+  }
+
+  .login-donthave-account {
+    @include h9;
+    text-align: center;
+  }
+
+  .login-other--login {
+    width: 150px;
+    margin-inline: auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    @media screen and (min-width: 768px) {
+      // styles for tablet and desktop
+      width: 100%;
+      @include flex-column;
+      gap: 16px;
+    }
+
+    button {
+      width: 56px;
+      height: 56px;
+      border-radius: 50%;
+      border: 2px solid #e2e8f0;
+      background-color: transparent;
+      padding: 16px;
+
+      @media screen and (min-width: 768px) {
+        width: 100%;
+        height: 48px;
+        border-radius: 8px;
+        padding: 12px 16px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
+    }
+
+    .login-alternative--text {
+      display: none;
+
+      @media screen and (min-width: 768px) {
+        display: inline;
+      }
+    }
+  }
+}

--- a/src/app/features/forgot-password/forgot-password.service.ts
+++ b/src/app/features/forgot-password/forgot-password.service.ts
@@ -1,0 +1,22 @@
+// mock service
+//actual service is implemented implemented by victor
+import { Injectable } from '@angular/core';
+import { Observable, of, throwError, delay } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ForgotPasswordService {
+  sendResetLink(email: string): Observable<{ message: string }> {
+    // Simulate valid/invalid email
+    const isValid = email.endsWith('@example.com');
+
+    if (isValid) {
+      return of({ message: 'Reset link sent successfully!' }).pipe(delay(2000));
+    } else {
+      return throwError(() => new Error('Email not found')).pipe(delay(2000));
+    }
+  }
+}
+
+// mock service

--- a/src/app/features/forgot-password/forgot-password.spec.ts
+++ b/src/app/features/forgot-password/forgot-password.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ForgotPassword } from './forgot-password';
+
+describe('ForgotPassword', () => {
+  let component: ForgotPassword;
+  let fixture: ComponentFixture<ForgotPassword>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ForgotPassword],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ForgotPassword);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/forgot-password/forgot-password.ts
+++ b/src/app/features/forgot-password/forgot-password.ts
@@ -7,11 +7,10 @@ import {
   Validators,
   FormControl,
 } from '@angular/forms';
-
-import { Subject } from 'rxjs';
-// import { LoginService } from './login.service';
+import { Subject, takeUntil } from 'rxjs';
 import { InputFieldComponent } from '../../shared/input-field/input-field';
 import { ToastService } from 'src/app/core/services/toast/toast-service';
+import { ForgotPasswordService } from './forgot-password.service';
 
 @Component({
   selector: 'app-forgot-password',
@@ -23,15 +22,15 @@ import { ToastService } from 'src/app/core/services/toast/toast-service';
 })
 export class ForgotPassword implements OnDestroy {
   loading = false;
-  loginForm: FormGroup;
+  forgotPasswordForm: FormGroup;
 
   private readonly destroy$ = new Subject<void>();
   private readonly fb = inject(FormBuilder);
-  // private readonly loginService = inject(LoginService);
   private readonly toastService = inject(ToastService);
+  private readonly forgotPasswordService = inject(ForgotPasswordService);
 
   constructor() {
-    this.loginForm = this.createForm();
+    this.forgotPasswordForm = this.createForm();
   }
 
   private createForm(): FormGroup {
@@ -41,38 +40,35 @@ export class ForgotPassword implements OnDestroy {
   }
 
   getControl(controlName: string): FormControl {
-    return this.loginForm.get(controlName) as FormControl;
+    return this.forgotPasswordForm.get(controlName) as FormControl;
   }
 
   login(): void {
-    if (this.loginForm.invalid) {
-      return;
-    }
+    if (this.forgotPasswordForm.invalid) return;
 
     this.loading = true;
+    const { email } = this.forgotPasswordForm.value;
 
-    // const email  = this.loginForm.value.email;
-
-    // this.loginService
-    //   .login(email, password)
-    //   .pipe(takeUntil(this.destroy$))
-    //   .subscribe({
-    //     next: () => {
-    //       this.toastService.showSuccess(
-    //         'Login Successful',
-    //         'Logged in successfully! Redirecting you to your dashboard...',
-    //       );
-    //       this.loading = false;
-    //     },
-    //     error: () => {
-    //       this.toastService.showError('Login Failed', 'Incorrect email or password.');
-    //       this.loading = false;
-    //     },
-    //   });
+    this.forgotPasswordService
+      .sendResetLink(email)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.toastService.showSuccess(
+            'Check your Inbox',
+            'A link to reset your password has been sent to your email.',
+          );
+          this.loading = false;
+        },
+        error: () => {
+          this.toastService.showError('Error', 'This email does not exist in our records.');
+          this.loading = false;
+        },
+      });
   }
 
-  public trydifferentemail(): void {
-    this.getControl('email').setValue(' ');
+  trydifferentemail(): void {
+    this.getControl('email').reset('');
   }
 
   ngOnDestroy(): void {

--- a/src/app/features/forgot-password/forgot-password.ts
+++ b/src/app/features/forgot-password/forgot-password.ts
@@ -1,0 +1,82 @@
+import { Component, OnDestroy, ChangeDetectionStrategy, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  ReactiveFormsModule,
+  FormBuilder,
+  FormGroup,
+  Validators,
+  FormControl,
+} from '@angular/forms';
+
+import { Subject } from 'rxjs';
+// import { LoginService } from './login.service';
+import { InputFieldComponent } from '../../shared/input-field/input-field';
+import { ToastService } from 'src/app/core/services/toast/toast-service';
+
+@Component({
+  selector: 'app-forgot-password',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, InputFieldComponent],
+  templateUrl: './forgot-password.html',
+  styleUrls: ['./forgot-password.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ForgotPassword implements OnDestroy {
+  loading = false;
+  loginForm: FormGroup;
+
+  private readonly destroy$ = new Subject<void>();
+  private readonly fb = inject(FormBuilder);
+  // private readonly loginService = inject(LoginService);
+  private readonly toastService = inject(ToastService);
+
+  constructor() {
+    this.loginForm = this.createForm();
+  }
+
+  private createForm(): FormGroup {
+    return this.fb.group({
+      email: ['', [Validators.required, Validators.email]],
+    });
+  }
+
+  getControl(controlName: string): FormControl {
+    return this.loginForm.get(controlName) as FormControl;
+  }
+
+  login(): void {
+    if (this.loginForm.invalid) {
+      return;
+    }
+
+    this.loading = true;
+
+    // const email  = this.loginForm.value.email;
+
+    // this.loginService
+    //   .login(email, password)
+    //   .pipe(takeUntil(this.destroy$))
+    //   .subscribe({
+    //     next: () => {
+    //       this.toastService.showSuccess(
+    //         'Login Successful',
+    //         'Logged in successfully! Redirecting you to your dashboard...',
+    //       );
+    //       this.loading = false;
+    //     },
+    //     error: () => {
+    //       this.toastService.showError('Login Failed', 'Incorrect email or password.');
+    //       this.loading = false;
+    //     },
+    //   });
+  }
+
+  public trydifferentemail(): void {
+    this.getControl('email').setValue(' ');
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}


### PR DESCRIPTION
This PR introduces a new Forgot Password page that allows users to request a password reset link.
The page includes a reactive form with validation, a mock service to simulate sending reset emails, and toast notifications for success and error feedback.

**Key Changes**

- Created ForgotPassword standalone component.
- Added form validation for email field (required, email).
- Integrated ToastService for user notifications.
- Implemented mock ForgotPasswordService to simulate API behavior.
- Added ChangeDetectionStrategy.OnPush for better performance.
- Included UI actions: resend email and try a different email.

**Testing Notes**

- Fill in a valid email and click Send Link → success toast should appear.
- Use invalid email → error toast should appear.
- Try a different email” resets the email input field.