### PR TITLE
feat(GSDT 243): interest selection layout

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,7 +30,88 @@ module.exports = tseslint.config(
           style: 'kebab-case',
         },
       ],
-      '@angular-eslint/prefer-on-push-component-change-detection': 'error',
+      complexity: 'off',
+      'max-classes-per-file': ['error', 1],
+      eqeqeq: ['error', 'always'],
+      indent: ['error', 2],
+      quotes: ['error', 'single'],
+      semi: ['error', 'always'],
+      '@typescript-eslint/switch-exhaustiveness-check': 'error',
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          args: 'none',
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+        },
+      ],
+      '@typescript-eslint/explicit-member-accessibility': [
+        'error',
+        {
+          accessibility: 'explicit',
+          ignoredMethodNames: [
+            'ngOnInit',
+            'ngOnDestroy',
+            'ngAfterViewInit',
+            'ngAfterContentInit',
+            'ngAfterViewChecked',
+            'ngAfterContentChecked',
+            'ngOnChanges',
+            'ngDoCheck',
+          ],
+          overrides: {
+            constructors: 'no-public',
+          },
+        },
+      ],
+      '@typescript-eslint/naming-convention': [
+        'error',
+        {
+          selector: ['enumMember', 'typeLike'],
+          format: ['PascalCase'],
+          custom: {
+            regex: '(My|my)(?=[A-Z]\\w*)',
+            match: false,
+          },
+        },
+        {
+          selector: ['parameter'],
+          format: ['camelCase'],
+          leadingUnderscore: 'allow',
+        },
+        {
+          selector: ['variable', 'function', 'method', 'classProperty', 'typeProperty'],
+          format: ['camelCase'],
+          custom: {
+            regex: '(My|my)(?=[A-Z]\\w*)',
+            match: false,
+          },
+        },
+        {
+          selector: ['variable'],
+          format: ['UPPER_CASE', 'camelCase'],
+          modifiers: ['global'],
+          custom: {
+            regex: '(My|my)(?=[A-Z]\\w*)',
+            match: false,
+          },
+        },
+        {
+          selector: ['variable'],
+          types: ['function'],
+          format: ['camelCase'],
+        },
+        {
+          selector: 'interface',
+          custom: {
+            regex: '[Ii](?=[A-Z]\\w*)',
+            match: false,
+          },
+          format: ['PascalCase'],
+        },
+      ],
+      'no-console': ['error', { allow: ['warn', 'error'] }],
     },
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,8 +12,16 @@ module.exports = tseslint.config(
       ...tseslint.configs.stylistic,
       ...angular.configs.tsRecommended,
     ],
+    languageOptions: {
+      parserOptions: {
+        project: './tsconfig.app.json',
+        ecmaVersion: 2020,
+        sourceType: 'module',
+      },
+    },
     processor: angular.processInlineTemplates,
     rules: {
+      '@angular-eslint/prefer-inject': 'off',
       '@angular-eslint/directive-selector': [
         'error',
         {

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,6 +1,5 @@
 import { Routes } from '@angular/router';
-import { authGuard } from './core/guards/auth-guard';
-import { guestGuard } from './core/guards/guest-guard';
+import { authGuard, guestGuard, onboardingGuard } from '@app/core';
 
 export const routes: Routes = [
   {
@@ -29,6 +28,7 @@ export const routes: Routes = [
       },
       {
         path: 'onboarding/level-selection',
+        canActivate: [onboardingGuard],
         loadComponent: () =>
           import('./features/level-selection/level-selection').then((c) => c.LevelSelection),
       },

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -27,6 +27,11 @@ export const routes: Routes = [
             (c) => c.EmailVerification,
           ),
       },
+      {
+        path: 'onboarding/level-selection',
+        loadComponent: () =>
+          import('./features/level-selection/level-selection').then((c) => c.LevelSelection),
+      },
     ],
   },
 

--- a/src/app/core/constants/app.constants.ts
+++ b/src/app/core/constants/app.constants.ts
@@ -3,4 +3,8 @@ export const APP_CONSTANTS = {
     COUNT: 2,
     DELAY_MS: 1000,
   },
+  FULL_PAGE_ROUTES: {
+    LEVEL_SELECTION: '/onboarding/level-selection',
+    INTEREST_SELECTION: '/onboarding/interest-selection',
+  },
 } as const;

--- a/src/app/core/guards/onboarding-guard.spec.ts
+++ b/src/app/core/guards/onboarding-guard.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateFn } from '@angular/router';
+
+import { onboardingGuard } from './onboarding-guard';
+
+describe('onboardingGuard', () => {
+  const executeGuard: CanActivateFn = (...guardParameters) =>
+    TestBed.runInInjectionContext(() => onboardingGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeGuard).toBeTruthy();
+  });
+});

--- a/src/app/core/guards/onboarding-guard.ts
+++ b/src/app/core/guards/onboarding-guard.ts
@@ -13,10 +13,10 @@ export const onboardingGuard: CanActivateFn = (route, state) => {
 
   const hasCompleted = authService.hasCompletedOnboarding();
 
-  if (!hasCompleted) {
-    return true;
+  if (hasCompleted) {
+    router.navigateByUrl('/dashboard');
+    return false;
   }
 
-  router.navigate(['/dashboard']);
-  return false;
+  return true;
 };

--- a/src/app/core/guards/onboarding-guard.ts
+++ b/src/app/core/guards/onboarding-guard.ts
@@ -1,0 +1,22 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../services/auth/auth-service';
+
+export const onboardingGuard: CanActivateFn = (route, state) => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (!authService.isAuthenticated()) {
+    router.navigate(['/login'], { queryParams: { returnUrl: state.url } });
+    return false;
+  }
+
+  const hasCompleted = authService.hasCompletedOnboarding();
+
+  if (!hasCompleted) {
+    return true;
+  }
+
+  router.navigate(['/dashboard']);
+  return false;
+};

--- a/src/app/core/index.ts
+++ b/src/app/core/index.ts
@@ -9,6 +9,8 @@ export * from './interceptors/global-http-error-interceptor';
 
 // guards
 export * from './guards/auth-guard';
+export * from './guards/onboarding-guard';
+export * from './guards/guest-guard';
 
 // constants
 export * from './constants/app.constants';

--- a/src/app/core/services/auth/auth-service.ts
+++ b/src/app/core/services/auth/auth-service.ts
@@ -26,6 +26,14 @@ export class AuthService {
     return this.api.post<AuthResponse>('auth/login', payload);
   }
 
+  public hasCompletedOnboarding(): boolean {
+    // TODO: Check a profile state property
+    // return this.userProfile.onboardingComplete === true;
+
+    // For a first-time user: return false
+    return false;
+  }
+
   logout() {
     localStorage.removeItem('token');
     this.currentUser.set(null);

--- a/src/app/features/level-selection/level-selection.html
+++ b/src/app/features/level-selection/level-selection.html
@@ -1,0 +1,1 @@
+<p>level-selection works!</p>

--- a/src/app/features/level-selection/level-selection.spec.ts
+++ b/src/app/features/level-selection/level-selection.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LevelSelection } from './level-selection';
+
+describe('LevelSelection', () => {
+  let component: LevelSelection;
+  let fixture: ComponentFixture<LevelSelection>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LevelSelection],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LevelSelection);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/level-selection/level-selection.ts
+++ b/src/app/features/level-selection/level-selection.ts
@@ -2,7 +2,6 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 @Component({
   selector: 'app-level-selection',
-  imports: [],
   templateUrl: './level-selection.html',
   styleUrl: './level-selection.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/features/level-selection/level-selection.ts
+++ b/src/app/features/level-selection/level-selection.ts
@@ -1,0 +1,10 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+@Component({
+  selector: 'app-level-selection',
+  imports: [],
+  templateUrl: './level-selection.html',
+  styleUrl: './level-selection.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LevelSelection {}

--- a/src/app/layout/landing-screen/landing-screen.html
+++ b/src/app/layout/landing-screen/landing-screen.html
@@ -1,6 +1,9 @@
-<app-navigation></app-navigation>
+@if (!isFullPageLayout()) {
+  <app-navigation></app-navigation>
+}
 <main>
-    <router-outlet></router-outlet>
+  <router-outlet></router-outlet>
 </main>
-<app-footer></app-footer>
-
+@if (!isFullPageLayout()) {
+  <app-footer></app-footer>
+}

--- a/src/app/layout/landing-screen/landing-screen.ts
+++ b/src/app/layout/landing-screen/landing-screen.ts
@@ -1,6 +1,13 @@
-import { ChangeDetectionStrategy, Component, WritableSignal, signal, OnInit } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  WritableSignal,
+  signal,
+  OnInit,
+  OnDestroy,
+} from '@angular/core';
 import { NavigationEnd, RouterOutlet, Router } from '@angular/router';
-import { filter } from 'rxjs';
+import { filter, Subject, takeUntil } from 'rxjs';
 
 import { Navigation } from '../../shared/compomonents/navigation/navigation';
 import { Footer } from '../../shared/compomonents/footer/footer';
@@ -12,13 +19,14 @@ import { APP_CONSTANTS } from '@app/core';
   styleUrl: './landing-screen.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class LandingScreen implements OnInit {
+export class LandingScreen implements OnInit, OnDestroy {
   private readonly fullPageRoutePaths: string[] = [
     APP_CONSTANTS.FULL_PAGE_ROUTES.LEVEL_SELECTION,
     APP_CONSTANTS.FULL_PAGE_ROUTES.INTEREST_SELECTION,
   ];
 
   public isFullPageLayout: WritableSignal<boolean> = signal(false);
+  private destroy$ = new Subject<void>();
 
   constructor(private router: Router) {}
 
@@ -29,11 +37,19 @@ export class LandingScreen implements OnInit {
     this.isFullPageLayout = signal(isInitialFullPage);
 
     this.router.events
-      .pipe(filter((event) => event instanceof NavigationEnd))
+      .pipe(
+        filter((event) => event instanceof NavigationEnd),
+        takeUntil(this.destroy$),
+      )
       .subscribe((event: NavigationEnd) => {
         const url = event.urlAfterRedirects;
 
         this.isFullPageLayout.set(this.fullPageRoutePaths.some((path) => url.includes(path)));
       });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 }

--- a/src/app/layout/landing-screen/landing-screen.ts
+++ b/src/app/layout/landing-screen/landing-screen.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, WritableSignal, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, WritableSignal, signal, OnInit } from '@angular/core';
 import { NavigationEnd, RouterOutlet, Router } from '@angular/router';
 import { filter } from 'rxjs';
 
@@ -12,16 +12,17 @@ import { APP_CONSTANTS } from '@app/core';
   styleUrl: './landing-screen.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class LandingScreen {
+export class LandingScreen implements OnInit {
   private readonly fullPageRoutePaths: string[] = [
     APP_CONSTANTS.FULL_PAGE_ROUTES.LEVEL_SELECTION,
     APP_CONSTANTS.FULL_PAGE_ROUTES.INTEREST_SELECTION,
   ];
 
-  public isFullPageLayout: WritableSignal<boolean>;
+  public isFullPageLayout: WritableSignal<boolean> = signal(false);
 
-  // eslint-disable-next-line @angular-eslint/prefer-inject
-  constructor(private router: Router) {
+  constructor(private router: Router) {}
+
+  ngOnInit() {
     const initialUrl = this.router.url;
     const isInitialFullPage = this.fullPageRoutePaths.some((path) => initialUrl.includes(path));
 

--- a/src/app/layout/landing-screen/landing-screen.ts
+++ b/src/app/layout/landing-screen/landing-screen.ts
@@ -1,12 +1,38 @@
-import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { ChangeDetectionStrategy, Component, WritableSignal, signal } from '@angular/core';
+import { NavigationEnd, RouterOutlet, Router } from '@angular/router';
+import { filter } from 'rxjs';
+
 import { Navigation } from '../../shared/compomonents/navigation/navigation';
 import { Footer } from '../../shared/compomonents/footer/footer';
-
+import { APP_CONSTANTS } from '@app/core';
 @Component({
   selector: 'app-landing-screen',
   imports: [RouterOutlet, Navigation, Footer],
   templateUrl: './landing-screen.html',
   styleUrl: './landing-screen.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class LandingScreen {}
+export class LandingScreen {
+  private readonly fullPageRoutePaths: string[] = [
+    APP_CONSTANTS.FULL_PAGE_ROUTES.LEVEL_SELECTION,
+    APP_CONSTANTS.FULL_PAGE_ROUTES.INTEREST_SELECTION,
+  ];
+
+  public isFullPageLayout: WritableSignal<boolean>;
+
+  // eslint-disable-next-line @angular-eslint/prefer-inject
+  constructor(private router: Router) {
+    const initialUrl = this.router.url;
+    const isInitialFullPage = this.fullPageRoutePaths.some((path) => initialUrl.includes(path));
+
+    this.isFullPageLayout = signal(isInitialFullPage);
+
+    this.router.events
+      .pipe(filter((event) => event instanceof NavigationEnd))
+      .subscribe((event: NavigationEnd) => {
+        const url = event.urlAfterRedirects;
+
+        this.isFullPageLayout.set(this.fullPageRoutePaths.some((path) => url.includes(path)));
+      });
+  }
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,7 +5,6 @@
   "compilerOptions": {
     "outDir": "./out-tsc/app",
     "types": ["node"],
-    "ignoreDeprecations": "6.0"
   },
   "include": [
     "src/**/*.ts"

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,6 +5,7 @@
   "compilerOptions": {
     "outDir": "./out-tsc/app",
     "types": ["node"],
+    "ignoreDeprecations": "6.0"
   },
   "include": [
     "src/**/*.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,9 +14,8 @@
     "importHelpers": true,
     "target": "ES2022",
     "module": "preserve",
-    "baseUrl": ".",
     "paths": {
-      "@app/core": ["./src/app/core"]
+      "@app/*": ["./src/app/*"]
     }
   },
   "angularCompilerOptions": {

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -4,11 +4,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
-    "types": [
-      "jasmine"
-    ],
+    "types": ["jasmine"]
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
This PR hides global navigation (Navbar and Footer) on specific routes Interest Selection to create a distraction-free, full-screen workflow. The layout is controlled by the `isFullPageLayout` signal within the `LandingScreen` component

Below is a quick video of what the PR entails:
https://www.loom.com/share/aecda10d5e184c19a5789610f00b2801?sid=a79f20aa-8ba2-4e7d-9dfa-68b590b26867
