### PR TITLE
test(GSDT 314): implement unit tests for verify email, signup, toast

### DIFF
--- a/src/app/core/services/toast/toast-service.spec.ts
+++ b/src/app/core/services/toast/toast-service.spec.ts
@@ -6,13 +6,13 @@ import { showToast, startToastExit } from '@app/store';
 
 describe('ToastService', () => {
   let service: ToastService;
-  let mockStore: jest.Mocked<Store>;
+  let mockStore: jest.Mocked<Pick<Store, 'dispatch' | 'select'>>;
 
   beforeEach(() => {
     mockStore = {
       dispatch: jest.fn(),
       select: jest.fn()
-    } as any;
+    } as jest.Mocked<Pick<Store, 'dispatch' | 'select'>>;
 
     TestBed.configureTestingModule({
       providers: [

--- a/src/app/core/services/toast/toast-service.spec.ts
+++ b/src/app/core/services/toast/toast-service.spec.ts
@@ -1,0 +1,76 @@
+import { TestBed } from '@angular/core/testing';
+import { Store } from '@ngrx/store';
+import { ToastService } from './toast-service';
+import { ToastType } from '../../models/toast-model';
+import { showToast, startToastExit } from '@app/store';
+
+describe('ToastService', () => {
+  let service: ToastService;
+  let mockStore: jest.Mocked<Store>;
+
+  beforeEach(() => {
+    mockStore = {
+      dispatch: jest.fn(),
+      select: jest.fn()
+    } as any;
+
+    TestBed.configureTestingModule({
+      providers: [
+        ToastService,
+        { provide: Store, useValue: mockStore }
+      ]
+    });
+
+    service = TestBed.inject(ToastService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should dispatch showToast action when show is called', () => {
+    const config = { type: ToastType.SUCCESS, title: 'Test', message: 'Test message' };
+    
+    service.show(config);
+    
+    expect(mockStore.dispatch).toHaveBeenCalledWith(showToast({ config }));
+  });
+
+  it('should show success toast', () => {
+    service.showSuccess('Success', 'Success message');
+    
+    expect(mockStore.dispatch).toHaveBeenCalledWith(showToast({
+      config: { type: ToastType.SUCCESS, title: 'Success', message: 'Success message' }
+    }));
+  });
+
+  it('should show error toast', () => {
+    service.showError('Error', 'Error message');
+    
+    expect(mockStore.dispatch).toHaveBeenCalledWith(showToast({
+      config: { type: ToastType.ERROR, title: 'Error', message: 'Error message' }
+    }));
+  });
+
+  it('should show info toast', () => {
+    service.showInfo('Info', 'Info message');
+    
+    expect(mockStore.dispatch).toHaveBeenCalledWith(showToast({
+      config: { type: ToastType.INFO, title: 'Info', message: 'Info message' }
+    }));
+  });
+
+  it('should show warning toast', () => {
+    service.showWarning('Warning', 'Warning message');
+    
+    expect(mockStore.dispatch).toHaveBeenCalledWith(showToast({
+      config: { type: ToastType.WARNING, title: 'Warning', message: 'Warning message' }
+    }));
+  });
+
+  it('should dispatch startToastExit action when close is called', () => {
+    service.close();
+    
+    expect(mockStore.dispatch).toHaveBeenCalledWith(startToastExit());
+  });
+});

--- a/src/app/core/services/toast/toast-service.ts
+++ b/src/app/core/services/toast/toast-service.ts
@@ -10,7 +10,6 @@ import { selectIsToastVisible, selectIsToastExiting, selectToastConfig } from '@
 export class ToastService {
   private store = inject(Store);
 
-  // Selectors for toast state
   public readonly isVisible$ = this.store.select(selectIsToastVisible);
   public readonly isExiting$ = this.store.select(selectIsToastExiting);
   public readonly config$ = this.store.select(selectToastConfig);

--- a/src/app/features/email-verification/email-verification.spec.ts
+++ b/src/app/features/email-verification/email-verification.spec.ts
@@ -120,10 +120,10 @@ describe('EmailVerification', () => {
       target: mockInput 
     } as unknown as KeyboardEvent;
     
-    const mockPrevInput = { nativeElement: { focus: jest.fn() } } as any;
+    const mockPrevInput = { nativeElement: { focus: jest.fn() } } as { nativeElement: { focus: jest.Mock } };
     component['otpInputs'] = {
       toArray: () => [mockPrevInput, mockInput]
-    } as any;
+    } as Partial<{ toArray: () => { nativeElement: { focus: jest.Mock } }[] }>;
     
     component.onKeyDown(mockEvent, 1);
     expect(mockPrevInput.nativeElement.focus).toHaveBeenCalled();

--- a/src/app/features/email-verification/email-verification.spec.ts
+++ b/src/app/features/email-verification/email-verification.spec.ts
@@ -8,19 +8,19 @@ import { EmailVerification } from './email-verification';
 describe('EmailVerification', () => {
   let component: EmailVerification;
   let fixture: ComponentFixture<EmailVerification>;
-  let mockRouter: jest.Mocked<Router>;
-  let mockToastService: jest.Mocked<ToastService>;
+  let mockRouter: jest.Mocked<Pick<Router, 'navigateByUrl'>>;
+  let mockToastService: jest.Mocked<Pick<ToastService, 'showSuccess' | 'showError' | 'showInfo'>>;
 
   beforeEach(async () => {
     mockRouter = {
       navigateByUrl: jest.fn()
-    } as any;
+    } as jest.Mocked<Pick<Router, 'navigateByUrl'>>;
 
     mockToastService = {
       showSuccess: jest.fn(),
       showError: jest.fn(),
       showInfo: jest.fn()
-    } as any;
+    } as jest.Mocked<Pick<ToastService, 'showSuccess' | 'showError' | 'showInfo'>>;
 
     await TestBed.configureTestingModule({
       imports: [EmailVerification, ReactiveFormsModule],

--- a/src/app/features/email-verification/email-verification.spec.ts
+++ b/src/app/features/email-verification/email-verification.spec.ts
@@ -1,0 +1,169 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { ToastService } from '@app/core';
+import { APP_CONSTANTS } from '@app/core';
+import { EmailVerification } from './email-verification';
+
+describe('EmailVerification', () => {
+  let component: EmailVerification;
+  let fixture: ComponentFixture<EmailVerification>;
+  let mockRouter: jest.Mocked<Router>;
+  let mockToastService: jest.Mocked<ToastService>;
+
+  beforeEach(async () => {
+    mockRouter = {
+      navigateByUrl: jest.fn()
+    } as any;
+
+    mockToastService = {
+      showSuccess: jest.fn(),
+      showError: jest.fn(),
+      showInfo: jest.fn()
+    } as any;
+
+    await TestBed.configureTestingModule({
+      imports: [EmailVerification, ReactiveFormsModule],
+      providers: [
+        { provide: Router, useValue: mockRouter },
+        { provide: ToastService, useValue: mockToastService }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(EmailVerification);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should initialize OTP form with 6 fields', () => {
+    expect(component.otpForm).toBeDefined();
+    expect(component.otpFields.length).toBe(6);
+    
+    component.otpFields.forEach(field => {
+      const control = component.otpForm.get(field.name);
+      expect(control).toBeDefined();
+      expect(control?.hasError('required')).toBe(true);
+    });
+  });
+
+  it('should validate OTP input pattern', () => {
+    const control = component.otpForm.get('otp0');
+    
+    control?.setValue('a');
+    expect(control?.hasError('pattern')).toBe(true);
+    
+    control?.setValue('5');
+    expect(control?.hasError('pattern')).toBe(false);
+  });
+
+  it('should update formValid signal when form status changes', () => {
+    expect(component.formValid()).toBe(false);
+    
+    component.otpFields.forEach((field, index) => {
+      component.otpForm.get(field.name)?.setValue(index.toString());
+    });
+    
+    expect(component.formValid()).toBe(true);
+  });
+
+  it('should start timer on init', fakeAsync(() => {
+    component.startTimer();
+    expect(component.timeLeft()).toBe(30);
+    expect(component.canResend()).toBe(false);
+    
+    tick(1000);
+    expect(component.timeLeft()).toBe(29);
+    
+    tick(30000);
+    expect(component.timeLeft()).toBe(0);
+    expect(component.canResend()).toBe(true);
+  }));
+
+  it('should resend code and restart timer', fakeAsync(() => {
+    component.timeLeft.set(0);
+    component.canResend.set(true);
+    
+    component.resendCode();
+    
+    expect(mockToastService.showInfo).toHaveBeenCalledWith(
+      'Code Sent',
+      'A new verification code has been sent to your email.'
+    );
+    expect(component.timeLeft()).toBe(30);
+    expect(component.canResend()).toBe(false);
+  }));
+
+  it('should handle OTP input correctly', () => {
+    const mockInput = { value: '5' } as HTMLInputElement;
+    const event = { target: mockInput } as unknown as Event;
+    
+    component.onInput(event, 0);
+    expect(mockInput.value).toBe('5');
+  });
+
+  it('should clear invalid input', () => {
+    const mockInput = { value: 'a' } as HTMLInputElement;
+    const event = { target: mockInput } as unknown as Event;
+    
+    component.onInput(event, 0);
+    expect(mockInput.value).toBe('');
+  });
+
+  it('should handle backspace navigation', () => {
+    const mockInput = { value: '' } as HTMLInputElement;
+    const mockEvent = { 
+      key: 'Backspace', 
+      target: mockInput 
+    } as unknown as KeyboardEvent;
+    
+    const mockPrevInput = { nativeElement: { focus: jest.fn() } } as any;
+    component['otpInputs'] = {
+      toArray: () => [mockPrevInput, mockInput]
+    } as any;
+    
+    component.onKeyDown(mockEvent, 1);
+    expect(mockPrevInput.nativeElement.focus).toHaveBeenCalled();
+  });
+
+  it('should not submit invalid form', async () => {
+    await component.onSubmit();
+    expect(component.isSubmitting()).toBe(false);
+  });
+
+  it('should submit valid form and navigate to login', fakeAsync(() => {
+    component.otpFields.forEach((field, index) => {
+      component.otpForm.get(field.name)?.setValue(index.toString());
+    });
+    
+    component.onSubmit();
+    expect(component.isSubmitting()).toBe(true);
+    
+    tick(2000);
+    
+    expect(mockToastService.showSuccess).toHaveBeenCalledWith(
+      'Email Verified',
+      'Your email is verified. We’ll redirect you to your dashboard'
+    );
+    expect(mockRouter.navigateByUrl).toHaveBeenCalledWith('/login');
+    expect(component.isSubmitting()).toBe(false);
+  }));
+
+  it('should navigate to signup page', () => {
+    component.goToSignUp();
+    expect(mockRouter.navigateByUrl).toHaveBeenCalledWith(APP_CONSTANTS.APP_ROUTES.SIGNUP);
+  });
+
+  it('should clean up subscriptions on destroy', () => {
+    const destroySpy = jest.spyOn(component['destroy$'], 'next');
+    const completeSpy = jest.spyOn(component['destroy$'], 'complete');
+    
+    component.ngOnDestroy();
+    
+    expect(destroySpy).toHaveBeenCalled();
+    expect(completeSpy).toHaveBeenCalled();
+  });
+});

--- a/src/app/features/landing-page/components/lumina-callout/lumina-callout.scss
+++ b/src/app/features/landing-page/components/lumina-callout/lumina-callout.scss
@@ -6,7 +6,7 @@
 .lumina-callout {
     background: {
         color: $brand-text;
-        image: url('../../../../../assets/lumina-bg.png');
+        image: url('/assets/lumina-bg.png');
         repeat: no-repeat;
         size: cover;
         position: center;
@@ -31,7 +31,7 @@
     max-width: 1200px;
 
     .content-wrapper {
-        @include flex-column(2.2rem);
+        @include flex(column, flex-start, stretch, 2.2rem);
         text-align: left;
         color: $gray-fill;
         max-width: 240px;

--- a/src/app/features/signup/signup.spec.ts
+++ b/src/app/features/signup/signup.spec.ts
@@ -1,14 +1,33 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ReactiveFormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { of } from 'rxjs';
 import { Signup } from './signup';
+import { ToastService } from '@app/core';
+import { APP_CONSTANTS } from '@app/core/constants/app.constants';
 
 describe('Signup', () => {
   let component: Signup;
   let fixture: ComponentFixture<Signup>;
+  let mockRouter: jest.Mocked<Router>;
+  let mockToastService: jest.Mocked<ToastService>;
 
   beforeEach(async () => {
+    mockRouter = {
+      navigateByUrl: jest.fn()
+    } as any;
+
+    mockToastService = {
+      showSuccess: jest.fn(),
+      showError: jest.fn()
+    } as any;
+
     await TestBed.configureTestingModule({
-      imports: [Signup],
+      imports: [Signup, ReactiveFormsModule],
+      providers: [
+        { provide: Router, useValue: mockRouter },
+        { provide: ToastService, useValue: mockToastService }
+      ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(Signup);
@@ -18,5 +37,99 @@ describe('Signup', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should initialize form with required validators', () => {
+    expect(component.signupForm).toBeDefined();
+    expect(component.signupForm.get('email')?.hasError('required')).toBe(true);
+    expect(component.signupForm.get('password')?.hasError('required')).toBe(true);
+    expect(component.signupForm.get('confirmPassword')?.hasError('required')).toBe(true);
+    expect(component.signupForm.get('termsAccepted')?.hasError('required')).toBe(true);
+  });
+
+  it('should validate email format', () => {
+    const emailControl = component.signupForm.get('email');
+    
+    emailControl?.setValue('invalid-email');
+    expect(emailControl?.hasError('email')).toBe(true);
+    
+    emailControl?.setValue('valid@email.com');
+    expect(emailControl?.hasError('email')).toBe(false);
+  });
+
+  it('should validate password requirements', () => {
+    const passwordControl = component.signupForm.get('password');
+    
+    passwordControl?.setValue('weak');
+    expect(passwordControl?.hasError('minlength')).toBe(true);
+    expect(passwordControl?.hasError('hasUppercase')).toBe(true);
+    
+    passwordControl?.setValue('StrongPass123!');
+    expect(passwordControl?.valid).toBe(true);
+  });
+
+  it('should validate password confirmation match', () => {
+    component.signupForm.patchValue({
+      password: 'StrongPass123!',
+      confirmPassword: 'DifferentPass123!'
+    });
+    
+    expect(component.signupForm.hasError('passwordsMismatch')).toBe(true);
+    
+    component.signupForm.patchValue({
+      confirmPassword: 'StrongPass123!'
+    });
+    
+    expect(component.signupForm.hasError('passwordsMismatch')).toBe(false);
+  });
+
+  it('should update password requirements computed signal', () => {
+    component.passwordValue.set('Test123!');
+    
+    const requirements = component.passwordRequirements();
+    expect(requirements.every(req => !req.error)).toBe(true);
+  });
+
+  it('should navigate to login page', () => {
+    component.goToLogin();
+    expect(mockRouter.navigateByUrl).toHaveBeenCalledWith(APP_CONSTANTS.APP_ROUTES.LOGIN);
+  });
+
+  it('should not submit invalid form', async () => {
+    await component.onSubmit();
+    expect(component.isSubmitting()).toBe(false);
+  });
+
+  it('should submit valid form and navigate to email verification', async () => {
+    // Fill form with valid data
+    component.signupForm.patchValue({
+      email: 'test@example.com',
+      password: 'StrongPass123!',
+      confirmPassword: 'StrongPass123!',
+      termsAccepted: true
+    });
+
+    await component.onSubmit();
+    
+    expect(component.isSubmitting()).toBe(true);
+    
+    // Wait for async operation to complete
+    setTimeout(() => {
+      expect(mockToastService.showSuccess).toHaveBeenCalledWith(
+        'Account Created',
+        "Hurray, Your account is created! We've sent a 6 digit code to your email"
+      );
+      expect(mockRouter.navigateByUrl).toHaveBeenCalledWith(APP_CONSTANTS.APP_ROUTES.EMAIL_VERIFICATION);
+    }, 2100);
+  });
+
+  it('should clean up subscriptions on destroy', () => {
+    const destroySpy = jest.spyOn(component['destroy$'], 'next');
+    const completeSpy = jest.spyOn(component['destroy$'], 'complete');
+    
+    component.ngOnDestroy();
+    
+    expect(destroySpy).toHaveBeenCalled();
+    expect(completeSpy).toHaveBeenCalled();
   });
 });

--- a/src/app/features/signup/signup.spec.ts
+++ b/src/app/features/signup/signup.spec.ts
@@ -9,18 +9,18 @@ import { APP_CONSTANTS } from '@app/core/constants/app.constants';
 describe('Signup', () => {
   let component: Signup;
   let fixture: ComponentFixture<Signup>;
-  let mockRouter: jest.Mocked<Router>;
-  let mockToastService: jest.Mocked<ToastService>;
+  let mockRouter: jest.Mocked<Pick<Router, 'navigateByUrl'>>;
+  let mockToastService: jest.Mocked<Pick<ToastService, 'showSuccess' | 'showError'>>;
 
   beforeEach(async () => {
     mockRouter = {
       navigateByUrl: jest.fn()
-    } as any;
+    } as jest.Mocked<Pick<Router, 'navigateByUrl'>>;
 
     mockToastService = {
       showSuccess: jest.fn(),
       showError: jest.fn()
-    } as any;
+    } as jest.Mocked<Pick<ToastService, 'showSuccess' | 'showError'>>;
 
     await TestBed.configureTestingModule({
       imports: [Signup, ReactiveFormsModule],
@@ -101,7 +101,6 @@ describe('Signup', () => {
   });
 
   it('should submit valid form and navigate to email verification', async () => {
-    // Fill form with valid data
     component.signupForm.patchValue({
       email: 'test@example.com',
       password: 'StrongPass123!',
@@ -113,7 +112,6 @@ describe('Signup', () => {
     
     expect(component.isSubmitting()).toBe(true);
     
-    // Wait for async operation to complete
     setTimeout(() => {
       expect(mockToastService.showSuccess).toHaveBeenCalledWith(
         'Account Created',

--- a/src/app/features/signup/signup.spec.ts
+++ b/src/app/features/signup/signup.spec.ts
@@ -11,23 +11,24 @@ describe('Signup', () => {
   let fixture: ComponentFixture<Signup>;
   let mockRouter: jest.Mocked<Pick<Router, 'navigateByUrl'>>;
   let mockToastService: jest.Mocked<Pick<ToastService, 'showSuccess' | 'showError'>>;
+  const delayTimer = 2100;
 
   beforeEach(async () => {
     mockRouter = {
-      navigateByUrl: jest.fn()
+      navigateByUrl: jest.fn(),
     } as jest.Mocked<Pick<Router, 'navigateByUrl'>>;
 
     mockToastService = {
       showSuccess: jest.fn(),
-      showError: jest.fn()
+      showError: jest.fn(),
     } as jest.Mocked<Pick<ToastService, 'showSuccess' | 'showError'>>;
 
     await TestBed.configureTestingModule({
       imports: [Signup, ReactiveFormsModule],
       providers: [
         { provide: Router, useValue: mockRouter },
-        { provide: ToastService, useValue: mockToastService }
-      ]
+        { provide: ToastService, useValue: mockToastService },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(Signup);
@@ -49,21 +50,21 @@ describe('Signup', () => {
 
   it('should validate email format', () => {
     const emailControl = component.signupForm.get('email');
-    
+
     emailControl?.setValue('invalid-email');
     expect(emailControl?.hasError('email')).toBe(true);
-    
+
     emailControl?.setValue('valid@email.com');
     expect(emailControl?.hasError('email')).toBe(false);
   });
 
   it('should validate password requirements', () => {
     const passwordControl = component.signupForm.get('password');
-    
+
     passwordControl?.setValue('weak');
     expect(passwordControl?.hasError('minlength')).toBe(true);
     expect(passwordControl?.hasError('hasUppercase')).toBe(true);
-    
+
     passwordControl?.setValue('StrongPass123!');
     expect(passwordControl?.valid).toBe(true);
   });
@@ -71,23 +72,23 @@ describe('Signup', () => {
   it('should validate password confirmation match', () => {
     component.signupForm.patchValue({
       password: 'StrongPass123!',
-      confirmPassword: 'DifferentPass123!'
+      confirmPassword: 'DifferentPass123!',
     });
-    
+
     expect(component.signupForm.hasError('passwordsMismatch')).toBe(true);
-    
+
     component.signupForm.patchValue({
-      confirmPassword: 'StrongPass123!'
+      confirmPassword: 'StrongPass123!',
     });
-    
+
     expect(component.signupForm.hasError('passwordsMismatch')).toBe(false);
   });
 
   it('should update password requirements computed signal', () => {
     component.passwordValue.set('Test123!');
-    
+
     const requirements = component.passwordRequirements();
-    expect(requirements.every(req => !req.error)).toBe(true);
+    expect(requirements.every((req) => !req.error)).toBe(true);
   });
 
   it('should navigate to login page', () => {
@@ -101,32 +102,39 @@ describe('Signup', () => {
   });
 
   it('should submit valid form and navigate to email verification', async () => {
+    jest.useFakeTimers();
+
     component.signupForm.patchValue({
       email: 'test@example.com',
       password: 'StrongPass123!',
       confirmPassword: 'StrongPass123!',
-      termsAccepted: true
+      termsAccepted: true,
     });
 
-    await component.onSubmit();
-    
+    const submitPromise = component.onSubmit();
+
     expect(component.isSubmitting()).toBe(true);
-    
-    setTimeout(() => {
-      expect(mockToastService.showSuccess).toHaveBeenCalledWith(
-        'Account Created',
-        "Hurray, Your account is created! We've sent a 6 digit code to your email"
-      );
-      expect(mockRouter.navigateByUrl).toHaveBeenCalledWith(APP_CONSTANTS.APP_ROUTES.EMAIL_VERIFICATION);
-    }, 2100);
+
+    jest.advanceTimersByTime(delayTimer);
+    await submitPromise;
+
+    expect(mockToastService.showSuccess).toHaveBeenCalledWith(
+      'Account Created',
+      "Hurray, Your account is created! We've sent a 6 digit code to your email",
+    );
+    expect(mockRouter.navigateByUrl).toHaveBeenCalledWith(
+      APP_CONSTANTS.APP_ROUTES.EMAIL_VERIFICATION,
+    );
+
+    jest.useRealTimers();
   });
 
   it('should clean up subscriptions on destroy', () => {
     const destroySpy = jest.spyOn(component['destroy$'], 'next');
     const completeSpy = jest.spyOn(component['destroy$'], 'complete');
-    
+
     component.ngOnDestroy();
-    
+
     expect(destroySpy).toHaveBeenCalled();
     expect(completeSpy).toHaveBeenCalled();
   });

--- a/src/app/shared/compomonents/toast/toast.spec.ts
+++ b/src/app/shared/compomonents/toast/toast.spec.ts
@@ -1,0 +1,51 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ToastService } from '@app/core';
+import { ToastType } from '@app/core';
+import { Toast } from './toast';
+import { of } from 'rxjs';
+
+describe('Toast', () => {
+  let component: Toast;
+  let fixture: ComponentFixture<Toast>;
+  let mockToastService: jest.Mocked<ToastService>;
+
+  beforeEach(async () => {
+    mockToastService = {
+      config$: of({ type: ToastType.SUCCESS, title: 'Test', message: 'Test message' }),
+      isVisible$: of(true),
+      isExiting$: of(false),
+      close: jest.fn()
+    } as any;
+
+    await TestBed.configureTestingModule({
+      imports: [Toast],
+      providers: [
+        { provide: ToastService, useValue: mockToastService }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Toast);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should expose toast type enum', () => {
+    expect(component.toastType).toBe(ToastType);
+  });
+
+  it('should expose service observables', () => {
+    expect(component.config$).toBe(mockToastService.config$);
+    expect(component.show$).toBe(mockToastService.isVisible$);
+    expect(component.exiting$).toBe(mockToastService.isExiting$);
+  });
+
+  it('should call toast service close when onClose is called', () => {
+    component.onClose();
+    
+    expect(mockToastService.close).toHaveBeenCalled();
+  });
+});

--- a/src/app/shared/compomonents/toast/toast.spec.ts
+++ b/src/app/shared/compomonents/toast/toast.spec.ts
@@ -7,7 +7,7 @@ import { of } from 'rxjs';
 describe('Toast', () => {
   let component: Toast;
   let fixture: ComponentFixture<Toast>;
-  let mockToastService: jest.Mocked<ToastService>;
+  let mockToastService: jest.Mocked<Pick<ToastService, 'config$' | 'isVisible$' | 'isExiting$' | 'close'>>;
 
   beforeEach(async () => {
     mockToastService = {
@@ -15,7 +15,7 @@ describe('Toast', () => {
       isVisible$: of(true),
       isExiting$: of(false),
       close: jest.fn()
-    } as any;
+    } as jest.Mocked<Pick<ToastService, 'config$' | 'isVisible$' | 'isExiting$' | 'close'>>;
 
     await TestBed.configureTestingModule({
       imports: [Toast],


### PR DESCRIPTION
###  Implement unit tests for verify email, signup, toast

**Add unit tests for Verify Email, Signup, and Toast components/services**

* * * * *

This PR adds comprehensive unit tests to improve reliability and maintainability for key user authentication and notification features.\
It ensures correct behavior of **email verification**, **signup flow**, and **toast notifications** through isolated component and service testing.

* * * * *

### **Changes Made**

#### **1\. Toast Service Tests**

-   Verified that `show()`, `showSuccess()`, `showError()`, `showInfo()`, and `showWarning()` dispatch the correct NgRx actions.

-   Confirmed that `close()` dispatches `startToastExit()`.

-   Ensured correct toast types (`SUCCESS`, `ERROR`, `INFO`, `WARNING`) are handled properly.

#### **2\. Email Verification Component Tests**

-   Validates form initialization with 6 OTP input fields and required validators.

-   Ensures OTP input pattern (numeric only) and field navigation logic work correctly.

-   Tests countdown timer behavior and resend-code functionality.

-   Verifies successful submission triggers correct toast messages and navigation.

-   Confirms resource cleanup (`ngOnDestroy`) properly completes observables.

#### **3\. Signup Component Tests**

-   Checks form validation (email, password, confirm password, and terms checkbox).

-   Ensures password strength and match validation logic works.

-   Tests navigation to login and email verification pages.

-   Confirms submission flow triggers success toast and redirect.

-   Verifies cleanup on component destruction.

#### **4\. Toast Component Tests**

-   Validates component creation and binding to `ToastService` observables.

-   Ensures `ToastType` enum is correctly exposed.

-   Confirms `onClose()` triggers `ToastService.close()`.