### PR TITLE
refactor(GSDT 316)!: replace old flex mixins with new @flex()

### DIFF
--- a/src/app/features/forgot-password/forgot-password.scss
+++ b/src/app/features/forgot-password/forgot-password.scss
@@ -4,21 +4,21 @@
 @use 'components' as *;
 
 .onboarding-login {
-  @include flex-column;
-   width: 90%;
-    margin-inline: auto;
-    margin-top: 2rem;
+  @include flex(column);
+  width: 90%;
+  margin-inline: auto;
+  margin-top: 2rem;
 
-    @media (min-width: 768px) {
-        width: 50%;
-        margin-left: auto;
-        margin-right: auto;
-    }
+  @media (min-width: 768px) {
+    width: 50%;
+    margin-left: auto;
+    margin-right: auto;
+  }
 
-    @media (min-width: 1200px) {
-        width: 600px;
-        max-width: 100%;
-    }
+  @media (min-width: 1200px) {
+    width: 600px;
+    max-width: 100%;
+  }
 
   h1 {
     @include h9;
@@ -43,8 +43,7 @@
   }
 
   form {
-    @include flex-column;
-    gap: 16px;
+    @include flex($direction: column, $gap: 16px);
     margin-top: 24px;
     margin-bottom: 24px;
 
@@ -71,9 +70,7 @@
         padding: 16px 12px;
         border-radius: 4px;
         overflow: hidden;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
+        @include flex(row, space-between, center);
 
         input {
           border: none;
@@ -90,9 +87,7 @@
           cursor: pointer;
           color: $gray-stroke-strong;
           font-size: 1.2rem;
-          display: flex;
-          align-items: center;
-          justify-content: center;
+          @include flex(row, center, center);
         }
       }
     }
@@ -138,15 +133,11 @@
   .login-other--login {
     width: 150px;
     margin-inline: auto;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
+    @include flex(row, space-between, center);
 
     @media screen and (min-width: 768px) {
-      // styles for tablet and desktop
       width: 100%;
-      @include flex-column;
-      gap: 16px;
+      @include flex($direction: column, $gap: 16px);
     }
 
     button {
@@ -162,10 +153,7 @@
         height: 48px;
         border-radius: 8px;
         padding: 12px 16px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        gap: 8px;
+        @include flex(row, center, center, 8px);
       }
     }
 

--- a/src/app/features/interests-selection/interests-selection.scss
+++ b/src/app/features/interests-selection/interests-selection.scss
@@ -5,8 +5,7 @@
 
 .interests {
   background: $background-white;
-  @include flex-column;
-  @include flex-center;
+  @include flex($direction: column, $align: center, $justify: center);
   height: 100vh;
 
   &-container {
@@ -15,8 +14,7 @@
     background-color: $gray-white;
 
     & > span {
-      @include flex-row;
-      gap: 2px;
+      @include flex($direction: row, $gap: 2px);
       margin-bottom: 32px;
     }
 
@@ -29,9 +27,8 @@
       color: $gray-text-strong;
     }
 
-    @include desktop{
-    max-width: 825px;
- 
+    @include desktop {
+      max-width: 825px;
     }
   }
 
@@ -41,8 +38,7 @@
 
   &-btns {
     margin-top: 26px;
-    @include flex-column;
-    gap: 16px;
+    @include flex($direction: column, $gap: 16px);
 
     & button {
       @include button-base;
@@ -57,7 +53,6 @@
       @include button-primary;
     }
   }
-
 }
 
 @include tablet {
@@ -74,12 +69,7 @@
     }
 
     &-btns {
-      @include flex-row;
-      @include flex-between;
+      @include flex($direction: row, $justify: space-between, $align: center);
     }
-
   }
 }
-
-
-

--- a/src/app/features/landing-page/components/features/features.scss
+++ b/src/app/features/landing-page/components/features/features.scss
@@ -3,39 +3,39 @@
 @use 'typography' as *;
 
 .features-section {
-    @include flex($direction: column, $justify: center, $align: center, $gap: 4rem);
-    padding: 4rem 0;
-    text-align: center;
-    width: 100%;
-    max-width: 1400px;
-    margin: 0 auto;
+  @include flex($direction: column, $justify: center, $align: center, $gap: 4rem);
+  padding: 4rem 0;
+  text-align: center;
+  width: 100%;
+  max-width: 1400px;
+  margin: 0 auto;
 }
 
 .section-header {
-    @include flex-column($gap: 1rem);
-    max-width: 700px;
+  @include flex($direction: column, $gap: 1rem);
+  max-width: 700px;
 
-    .section-title {
-        @include h5;
-        color: $gray-text-strong;
+  .section-title {
+    @include h5;
+    color: $gray-text-strong;
+  }
+
+  .section-subtitle {
+    @include h13;
+    color: $gray-stroke-strong;
+
+    @include tablet {
+      @include h12;
     }
-
-    .section-subtitle {
-        @include h13;
-        color: $gray-stroke-strong;
-
-        @include tablet {
-            @include h12;
-        }
-    }
+  }
 }
 
 .features-grid {
-    @include flex($direction: column, $gap: 2rem);
-    width: 100%;
+  @include flex($direction: column, $gap: 2rem);
+  width: 100%;
 
-    @include tablet {
-        display: grid;
-        grid-template-columns: repeat(3, 1fr);
-    }
+  @include tablet {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+  }
 }

--- a/src/app/features/login/login.scss
+++ b/src/app/features/login/login.scss
@@ -4,21 +4,21 @@
 @use 'components' as *;
 
 .onboarding-login {
-  @include flex-column;
-   width: 90%;
-    margin-inline: auto;
-    margin-top: 2rem;
+  @include flex(column);
+  width: 90%;
+  margin-inline: auto;
+  margin-top: 2rem;
 
-    @media (min-width: 768px) {
-        width: 50%;
-        margin-left: auto;
-        margin-right: auto;
-    }
+  @media (min-width: 768px) {
+    width: 50%;
+    margin-left: auto;
+    margin-right: auto;
+  }
 
-    @media (min-width: 1200px) {
-        width: 600px;
-        max-width: 100%;
-    }
+  @media (min-width: 1200px) {
+    width: 600px;
+    max-width: 100%;
+  }
 
   h1 {
     @include h11;
@@ -43,8 +43,7 @@
   }
 
   form {
-    @include flex-column;
-    gap: 16px;
+    @include flex($direction: column, $gap: 16px);
     margin-top: 24px;
     margin-bottom: 24px;
 
@@ -71,9 +70,7 @@
         padding: 16px 12px;
         border-radius: 4px;
         overflow: hidden;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
+        @include flex(row, space-between, center);
 
         input {
           border: none;
@@ -90,9 +87,7 @@
           cursor: pointer;
           color: $gray-stroke-strong;
           font-size: 1.2rem;
-          display: flex;
-          align-items: center;
-          justify-content: center;
+          @include flex(row, center, center);
         }
       }
     }
@@ -125,15 +120,11 @@
   .login-other--login {
     width: 150px;
     margin-inline: auto;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
+    @include flex(row, space-between, center);
 
     @media screen and (min-width: 768px) {
-      // styles for tablet and desktop
       width: 100%;
-      @include flex-column;
-      gap: 16px;
+      @include flex($direction: column, $gap: 16px);
     }
 
     button {
@@ -149,10 +140,7 @@
         height: 48px;
         border-radius: 8px;
         padding: 12px 16px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        gap: 8px;
+        @include flex(row, center, center, 8px);
       }
     }
 

--- a/src/app/features/reset-password/reset-password.scss
+++ b/src/app/features/reset-password/reset-password.scss
@@ -3,187 +3,162 @@
 @use 'typography' as *;
 @use 'components' as *;
 
-.onboarding-login{
-    @include flex-column;
-    width: 90%;
-    margin-inline: auto;
-    margin-top: 2rem;
+.onboarding-login {
+  @include flex(column);
+  width: 90%;
+  margin-inline: auto;
+  margin-top: 2rem;
 
-    @media (min-width: 768px) {
-        width: 50%;
-        margin-left: auto;
-        margin-right: auto;
+  @media (min-width: 768px) {
+    width: 50%;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  @media (min-width: 1200px) {
+    width: 600px;
+    max-width: 100%;
+  }
+
+  h1 {
+    @include h9;
+    height: 36px;
+    margin-bottom: 8px;
+  }
+  p {
+    @include h13;
+    color: $gray-text-strong;
+  }
+
+  form {
+    @include flex($direction: column, $gap: 16px);
+    margin-top: 24px;
+    margin-bottom: 24px;
+
+    .error-message {
+      color: #e74c3c;
+      font-size: 0.8rem;
+      margin-top: 4px;
     }
 
-    @media (min-width: 1200px) {
-        width: 600px;
-        max-width: 100%;
+    .login-input--group {
+      @include base-field;
     }
 
-    h1{
-        @include h9; 
-        height: 36px;
-        margin-bottom: 8px;
-      
-    }
-    p{
+    .login-inputgroup-password {
+      label {
         @include h13;
         color: $gray-text-strong;
+      }
+      .input-password {
+        @include h12;
+        background-color: transparent;
+        color: $gray-stroke-strong;
+        border: 1px solid $gray-stroke-strong;
+        padding: 16px 12px;
+        border-radius: 4px;
+        overflow: hidden;
+        @include flex(row, space-between, center);
 
-       
+        input {
+          border: none;
+          outline: none;
+          width: 90%;
+          background-color: transparent;
+          color: $gray-stroke-strong;
+          @include h12;
+        }
+
+        .password-toggle {
+          background: none;
+          border: none;
+          cursor: pointer;
+          color: $gray-stroke-strong;
+          font-size: 1.2rem;
+          @include flex(row, center, center);
+        }
+      }
     }
 
-    form{
-        @include flex-column;
-        gap: 16px;
-        margin-top: 24px;
-        margin-bottom: 24px;
-
-        .error-message {
-        color: #e74c3c;
-        font-size: 0.8rem;
-        margin-top: 4px;
-    }
-
-
-        .login-input--group{
-            @include base-field;
-        }
-
-        .login-inputgroup-password{
-           
-             label {
-            @include h13;
-            color: $gray-text-strong;
-            }
-            .input-password{
-                @include h12;
-                background-color: transparent;
-                color: $gray-stroke-strong;
-                border: 1px solid $gray-stroke-strong;
-                padding: 16px 12px;
-                border-radius: 4px;
-                overflow: hidden;
-                display: flex;
-                align-items: center;
-                justify-content: space-between;
-
-                input{
-                    border: none;
-                    outline: none;
-                    width: 90%;
-                    background-color: transparent;
-                    color: $gray-stroke-strong;
-                    @include h12;
-
-                }
-
-                .password-toggle{
-                    background: none;
-                    border: none;
-                    cursor: pointer;
-                    color: $gray-stroke-strong;
-                    font-size: 1.2rem;
-                    display: flex;
-                    align-items: center;
-                    justify-content: center;
-                }
-            }
-
-        }
-
-       
-        .login-button{
-            @include button-primary;
-            margin-top: 8px;
-            @include h9
-        }
-    }
-
-    .login-or{
-            @include h9;
-            text-align: center;
-            padding-block: 15px;
-            color: $gray-text-strong;
-    }
-
-     a{
-            @include h9;
-            text-decoration: none;
-            color: $brand-text;
-        }
-
-        .login-donthave-account{
-            @include h9;
-            text-align: center;
-
-        }
-
-        .login-other--login{
-           width: 150px;
-           margin-inline: auto;
-           display: flex;
-           align-items: center;
-           justify-content: space-between;
-
-           @media screen and (min-width: 768px) {
-               // styles for tablet and desktop
-                width: 100%;
-                @include flex-column;
-                gap: 16px;
-           }
-
-           button{
-            width: 56px;
-            height: 56px;
-            border-radius: 50%;
-            border: 2px solid #E2E8F0;
-            background-color: transparent;
-            padding: 16px;
-
-            @media screen and (min-width: 768px){
-                width: 100%;
-                height: 48px;
-                border-radius: 8px;
-                padding: 12px 16px;
-                display: flex;
-                align-items: center;
-                justify-content: center;
-                gap: 8px;
-            }
-           }
-
-           .login-alternative--text{
-            display: none;
-
-            @media screen and (min-width: 768px){
-                display: inline;
-            }
-           }
-        }
-
-        .password-strength {
-  list-style: none;
-  padding-left: 0;
-  margin: 0.5rem 0 1rem;
-
-  li {
-    font-size: 0.9rem;
-    color: $gray-text-weak;
-    margin-bottom: 4px;
-    @include h13;
-    font-style: regular;
-
-    &.valid {
-      color: $green-text; 
-      font-weight: 500;
-      @include h13;
-
+    .login-button {
+      @include button-primary;
+      margin-top: 8px;
+      @include h9;
     }
   }
-}
 
+  .login-or {
+    @include h9;
+    text-align: center;
+    padding-block: 15px;
+    color: $gray-text-strong;
+  }
 
+  a {
+    @include h9;
+    text-decoration: none;
+    color: $brand-text;
+  }
 
+  .login-donthave-account {
+    @include h9;
+    text-align: center;
+  }
 
+  .login-other--login {
+    width: 150px;
+    margin-inline: auto;
+    @include flex(row, space-between, center);
+
+    @media screen and (min-width: 768px) {
+      // styles for tablet and desktop
+      width: 100%;
+      @include flex($direction: column, $gap: 16px);
+    }
+
+    button {
+      width: 56px;
+      height: 56px;
+      border-radius: 50%;
+      border: 2px solid #e2e8f0;
+      background-color: transparent;
+      padding: 16px;
+
+      @media screen and (min-width: 768px) {
+        width: 100%;
+        height: 48px;
+        border-radius: 8px;
+        padding: 12px 16px;
+        @include flex(row, center, center, 8px);
+      }
+    }
+
+    .login-alternative--text {
+      display: none;
+
+      @media screen and (min-width: 768px) {
+        display: inline;
+      }
+    }
+  }
+
+  .password-strength {
+    list-style: none;
+    padding-left: 0;
+    margin: 0.5rem 0 1rem;
+
+    li {
+      font-size: 0.9rem;
+      color: $gray-text-weak;
+      margin-bottom: 4px;
+      @include h13;
+      font-style: regular;
+
+      &.valid {
+        color: $green-text;
+        font-weight: 500;
+        @include h13;
+      }
+    }
+  }
 }

--- a/src/app/shared/compomonents/feature-section/feature-section.scss
+++ b/src/app/shared/compomonents/feature-section/feature-section.scss
@@ -3,49 +3,49 @@
 @use 'typography' as *;
 
 .features-section {
-    @include flex($direction: column, $justify: center, $align: center, $gap: 4rem);
-    padding: 4rem 0 0;
-    text-align: center;
-    width: 100%;
-    max-width: 1400px;
-    margin: 0 auto;
+  @include flex(column, center, center, 4rem);
+  padding: 4rem 0 0;
+  text-align: center;
+  width: 100%;
+  max-width: 1400px;
+  margin: 0 auto;
 }
 
 .section-header {
-    @include flex-column($gap: 1rem);
-    max-width: 700px;
+  @include flex($direction: column, $gap: 1rem);
+  max-width: 700px;
 
-    .section-title {
-        @include h5;
-        color: $gray-text-strong;
+  .section-title {
+    @include h5;
+    color: $gray-text-strong;
+  }
+
+  .section-subtitle {
+    @include h13;
+    color: $gray-stroke-strong;
+
+    @include tablet {
+      @include h12;
     }
-
-    .section-subtitle {
-        @include h13;
-        color: $gray-stroke-strong;
-
-        @include tablet {
-            @include h12;
-        }
-    }
+  }
 }
 
 .features-grid {
-    @include flex($direction: column, $gap: 2rem);
-    width: 100%;
+  @include flex($direction: column, $gap: 2rem);
+  width: 100%;
 
+  @include tablet {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  &.skill-development {
     @include tablet {
-        display: grid;
-        grid-template-columns: repeat(3, 1fr);
+      grid-template-columns: repeat(2, 1fr);
     }
 
-    &.skill-development {
-        @include tablet {
-            grid-template-columns: repeat(2, 1fr);
-        }
-
-        @include desktop {
-            grid-template-columns: repeat(4, 1fr);
-        }
+    @include desktop {
+      grid-template-columns: repeat(4, 1fr);
     }
+  }
 }

--- a/src/app/shared/compomonents/footer/footer.scss
+++ b/src/app/shared/compomonents/footer/footer.scss
@@ -3,131 +3,119 @@
 @use 'typography' as *;
 @use 'components' as *;
 
-footer{
-    @include flex-column;
-    @include h13;
-    background-color: $background-dark;
-    color: $background-white;
-    padding: 40px 20px;
+footer {
+  @include flex(column);
+  @include h13;
+  background-color: $background-dark;
+  color: $background-white;
+  padding: 40px 20px;
 
-    .container{
-    @include flex-column;
-    gap: 20px;
+  .container {
+    @include flex($direction: column, $gap: 20px);
     padding: 30px;
     border: 1px solid $background-white;
+  }
+
+  .about-us {
+    gap: 20px;
+
+    .title {
+      margin-bottom: 20px;
+      @include h11;
+    }
+  }
+
+  .links-socials {
+    display: none;
+
+    @include desktop {
+      @include flex(row);
+      margin-top: 20px;
+    }
+  }
+
+  .copyright-terms {
+    margin-top: 30px;
+    @include flex(row);
+  }
+
+  .links {
+    width: 50%;
+
+    .title {
+      margin-bottom: 20px;
+      @include h11;
+    }
+    a {
+      text-decoration: none;
+      color: $background-white;
     }
 
-    .about-us{
-        gap: 20px;
+    li {
+      list-style-type: none;
+      margin-bottom: 15px;
+    }
+  }
 
-        .title{
-            margin-bottom: 20px;
-            @include h11;
-        }
+  .connect {
+    width: 50%;
+
+    .title {
+      margin-bottom: 20px;
+      @include h11;
     }
 
-    .links-socials{
-        
+    .socials {
+      @include flex($direction: row, $gap: 15px);
 
-        display: none;
+      a {
+        text-decoration: none;
+        color: $background-white;
+      }
 
-        @include desktop{
-            display: flex;
-           margin-top: 20px;
-        }
+      li {
+        list-style-type: none;
+        margin-bottom: 30px;
+      }
+    }
+  }
+
+  .terms {
+    width: 60%;
+    a {
+      text-decoration: none;
+      color: $background-white;
     }
 
-    .copyright-terms{
-       margin-top: 30px;
-       display: flex;
+    li {
+      list-style-type: none;
+      margin-bottom: 30px;
+    }
+  }
+
+  @media (min-width: 768px) {
+    .container {
+      @include flex(row, space-between, baseline);
     }
 
-    .links{
-        width: 50%;
-
-        .title{
-            margin-bottom: 20px;
-            @include h11;
-        }
-        a{
-            text-decoration: none;
-            color: $background-white;
-        }
-
-        li{
-            list-style-type: none;
-            margin-bottom: 15px;
-        }
+    .links-socials,
+    .about-us {
+      width: 40%;
     }
 
-    .connect{
-        width: 50%;
-
-        .title{
-            margin-bottom: 20px;
-            @include h11;
-        }
-
-        .socials{
-
-            @include flex;
-            gap: 15px;
-
-         a{
-            text-decoration: none;
-            color: $background-white;
-        }
-
-        li{
-            list-style-type: none;
-            margin-bottom: 30px;
-        }
-        }
+    .copyright-terms {
+      @include flex($direction: row-reverse, $align: space-between);
     }
 
-    .terms{
-        width: 60%;
-        a{
-            text-decoration: none;
-            color: $background-white;
-        }
+    .terms {
+      li {
+        display: inline;
+        margin-left: 22px;
+      }
 
-        li{
-            list-style-type: none;
-            margin-bottom: 30px;
-        }
+      ul {
+        text-align: right;
+      }
     }
-
-    @media (min-width: 768px) {
-        
-
-        .container{
-            flex-direction: row;
-            justify-content: space-between;
-            align-items:first baseline
-        }
-
-        .links-socials, .about-us{
-            width: 40%;
-        }
-
-        .copyright-terms{
-            @include flex-between;
-            flex-direction: row-reverse;
-        }
-
-        .terms {
-
-        li{
-            display: inline;
-            margin-left: 22px;
-           }
-
-        ul{
-            text-align: right;
-        }   
-       }
-
-        
-    }
+  }
 }

--- a/src/app/shared/compomonents/navigation/navigation.scss
+++ b/src/app/shared/compomonents/navigation/navigation.scss
@@ -161,11 +161,11 @@
 
 @media (min-width: 768px) {
   .nav-menu {
-    @include flex(row);
+    @include flex($direction: row, $gap: 20px);
   }
 
   .nav-actions {
-    @include flex(row);
+    @include flex($direction: row, $align: center, $gap: 20px);
   }
 
   .hamburger {

--- a/src/app/shared/compomonents/navigation/navigation.scss
+++ b/src/app/shared/compomonents/navigation/navigation.scss
@@ -3,175 +3,172 @@
 @use 'typography' as *;
 @use 'components' as *;
 
- * {
-      margin: 0;
-      padding: 0;
-      box-sizing: border-box;
-    }
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
 
-    .navbar {
-      background-color: $brand-fill-weak;
-      padding: 16px 24px;
-    }
+.navbar {
+  background-color: $brand-fill-weak;
+  padding: 16px 24px;
+}
 
-    .navbar-container {
-      width: 100%;
-      margin: 0 auto;
-      @include flex-between;
-    }
+.navbar-container {
+  width: 100%;
+  margin: 0 auto;
+  @include flex($direction: row, $justify: space-between, $align: center);
+}
 
-    .logo {
-      font-size: 20px;
-      color: $brand-text;
-      text-decoration: none;
-    }
+.logo {
+  font-size: 20px;
+  color: $brand-text;
+  text-decoration: none;
+}
 
-    .nav-menu {
-      display: none;
-      align-items: center;
-      gap: 40px;
-    }
+.nav-menu {
+  display: none;
+  align-items: center;
+  gap: 40px;
+}
 
-    .nav-menu a {
-      color: $gray-text-strong;
-      text-decoration: none;
-      @include h13;
-      transition: color 0.2s;
-    }
+.nav-menu a {
+  color: $gray-text-strong;
+  text-decoration: none;
+  @include h13;
+  transition: color 0.2s;
+}
 
-    .nav-menu a:hover {
-      color: $brand-text;
-    }
+.nav-menu a:hover {
+  color: $brand-text;
+}
 
-    .nav-menu a.active {
-      color: $brand-text;
-      border-bottom: 0.5px solid $brand-text;
-      padding-bottom: 4px;
-    }
+.nav-menu a.active {
+  color: $brand-text;
+  border-bottom: 0.5px solid $brand-text;
+  padding-bottom: 4px;
+}
 
-    .nav-actions {
-      display: none;
-      align-items: center;
-      gap: 24px;
-    }
+.nav-actions {
+  display: none;
+  align-items: center;
+  gap: 24px;
+}
 
-    .login-btn {
-      color: $brand-text;
-      text-decoration: none;
-      @include h12;
-    }
+.login-btn {
+  color: $brand-text;
+  text-decoration: none;
+  @include h12;
+}
 
-    .signup-btn {
-      background-color: $brand-text;
-      @include button-primary;
-      transition: background-color 0.2s;
-      @include h12;
-    }
+.signup-btn {
+  background-color: $brand-text;
+  @include button-primary;
+  transition: background-color 0.2s;
+  @include h12;
+}
 
-    .signup-btn:hover {
-      background-color: $brand-text;
-    }
+.signup-btn:hover {
+  background-color: $brand-text;
+}
 
-    .hamburger {
-      display: block;
-      cursor: pointer;
-      background: none;
-      border: none;
-    }
+.hamburger {
+  display: block;
+  cursor: pointer;
+  background: none;
+  border: none;
+}
 
-    .hamburger span {
-      display: block;
-      width: 24px;
-      height: 2px;
-      background-color: $gray-text-strong;
-      margin: 5px 0;
-    }
+.hamburger span {
+  display: block;
+  width: 24px;
+  height: 2px;
+  background-color: $gray-text-strong;
+  margin: 5px 0;
+}
 
-    .mobile-menu {
-      display: none;
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      background-color: $background-white;
-      z-index: 1000;
-      padding: 24px;
-      overflow-y: auto;
-    }
+.mobile-menu {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: $background-white;
+  z-index: 1000;
+  padding: 24px;
+  overflow-y: auto;
+}
 
-    .mobile-menu.active {
-      display: block;
-    }
+.mobile-menu.active {
+  display: block;
+}
 
-    .mobile-header {
-      @include flex-between;
-      margin-bottom: 32px;
-      padding-bottom: 16px;
-      border-bottom: 1px solid $gray-stroke-weak;
-    }
+.mobile-header {
+  @include flex($direction: row, $justify: space-between, $align: center);
+  margin-bottom: 32px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid $gray-stroke-weak;
+}
 
-    .close-btn {
-      background: none;
-      border: none;
-      font-size: 28px;
-      color: $gray-text-strong;
-      cursor: pointer;
-      line-height: 1;
-    }
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 28px;
+  color: $gray-text-strong;
+  cursor: pointer;
+  line-height: 1;
+}
 
-    .mobile-nav-items {
-      @include flex-column;
-      gap: 24px;
-      margin-bottom: 32px;
-    }
+.mobile-nav-items {
+  @include flex($direction: column, $gap: 24px);
+  margin-bottom: 32px;
+}
 
-    .mobile-nav-items a {
-      color: $gray-text-strong;
-      text-decoration: none;
-      font-size: 16px;
-      padding: 8px 0;
-    }
+.mobile-nav-items a {
+  color: $gray-text-strong;
+  text-decoration: none;
+  font-size: 16px;
+  padding: 8px 0;
+}
 
-    .mobile-nav-items a.active {
-      color: $brand-text;
-      border-bottom: 0.5px solid $brand-text;
-      width: 20%;
-    }
+.mobile-nav-items a.active {
+  color: $brand-text;
+  border-bottom: 0.5px solid $brand-text;
+  width: 20%;
+}
 
-    .mobile-actions {
-     @include flex-column;
-      gap: 16px;
-    }
+.mobile-actions {
+  @include flex($direction: column, $gap: 16px);
+}
 
-    .mobile-login {
-      text-align: center;
-      color: $brand-text;
-      text-decoration: none;
-      @include h12;
-      padding: 12px;
-    }
+.mobile-login {
+  text-align: center;
+  color: $brand-text;
+  text-decoration: none;
+  @include h12;
+  padding: 12px;
+}
 
-    .mobile-signup {
-      background-color: $brand-text;
-      @include button-primary;
-      text-decoration: none;
-      font-size: 16px;
-      font-weight: 500;
-      text-align: center;
-    }
+.mobile-signup {
+  background-color: $brand-text;
+  @include button-primary;
+  text-decoration: none;
+  font-size: 16px;
+  font-weight: 500;
+  text-align: center;
+}
 
-    @media (min-width: 768px) {
-      .nav-menu {
-        display: flex;
-      }
+@media (min-width: 768px) {
+  .nav-menu {
+    @include flex(row);
+  }
 
-      .nav-actions {
-        display: flex;
-      }
+  .nav-actions {
+    @include flex(row);
+  }
 
-      .hamburger {
-        display: none;
-      }
-    }
-  
+  .hamburger {
+    display: none;
+  }
+}

--- a/src/app/shared/compomonents/skill-level-selector/skill-level-selector.scss
+++ b/src/app/shared/compomonents/skill-level-selector/skill-level-selector.scss
@@ -4,8 +4,7 @@
 @use 'components' as *;
 
 .skill-card {
-  @include flex-column;
-  align-items: flex-start;
+  @include flex(column);
   background: transparent;
   padding: 12px 16px;
   width: fit-content;
@@ -13,8 +12,8 @@
 }
 
 .skill-header {
-  @include flex-center;
-  gap: 6px;
+  @include flex(row, center, center, 6px);
+
   margin-bottom: 10px;
 
   .icon {

--- a/src/app/shared/input-field/input-field.scss
+++ b/src/app/shared/input-field/input-field.scss
@@ -2,7 +2,7 @@
 @use 'typography' as *;
 @use 'mixins' as *;
 @use 'components' as *;
-/* Base input field container */
+
 .form-group {
   @include base-field;
   width: 100%;
@@ -39,22 +39,19 @@
     }
   }
 
-  /* Wrapper for positioning eye toggle */
   .input-wrapper {
     position: relative;
-    display: flex;
-    align-items: center;
+    @include flex($direction: row, $align: center);
 
     input {
       padding-right: 40px;
     }
 
     .password-toggle {
-      @include flex-center;
+      @include flex(row, center, center);
       position: absolute;
       right: 12px;
       cursor: pointer;
-      align-items: center;
 
       img {
         width: 20px;
@@ -63,14 +60,11 @@
     }
   }
 
-  /* Error message styling */
   .error-message {
     @include h13;
     color: $red-text;
     margin-top: 4px;
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
+    @include flex($direction: column, $gap: 2px);
 
     small {
       display: block;
@@ -78,7 +72,6 @@
   }
 }
 
-/* Password-specific styling */
 .password-field {
   .input-wrapper {
     input {
@@ -99,18 +92,14 @@
   }
 }
 
-/* Password strength / requirement list */
 .password-requirements {
   list-style: none;
   padding: 0;
   margin: 8px 0 0 0;
-  @include flex-column;
-  gap: 4px;
+  @include flex($direction: column, $gap: 4px);
 
   li {
-    @include flex-center;
-    justify-content: flex-start;
-    gap: 8px;
+    @include flex(row, flex-start, center, 8px);
     @include h13;
     color: $red-text;
 

--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -2,13 +2,13 @@
 @use 'typography' as *;
 @use 'mixins' as *;
 
-@mixin button-base (
+@mixin button-base(
   $padding-y: 0.75rem,
   $padding-x: 1.6rem,
   $border-radius: 0.5rem,
-  $font-size: 1.25rem,      
+  $font-size: 1.25rem,
   $font-weight: 400,
-  $line-height: 1.5rem,
+  $line-height: 1.5rem
 ) {
   padding: $padding-y $padding-x;
   width: 100%;
@@ -61,8 +61,7 @@
 }
 
 @mixin base-field {
-  @include flex-column;
-  gap: 4px;
+  @include flex($direction: column, $gap: 4px);
 
   // label
   label {
@@ -84,9 +83,7 @@
 
 // alert-box
 @mixin alert-box($bg-color, $border-color, $text-color) {
-  @include flex-center;
-
-  gap: 1.25rem;
+  @include flex($direction: row, $justify: center, $align: center, $gap: 1.25rem);
   padding: 1rem;
   border-radius: 8px;
   border: 1px solid $border-color;
@@ -104,12 +101,10 @@
 
   .alert-content {
     flex: 1;
-    @include flex-column;
-    gap: 1rem;
+    @include flex($direction: column, $gap: 1rem);
 
     .alert-header {
-      display: flex;
-      justify-content: space-between;
+      @include flex($direction: row, $justify: space-between);
 
       .alert-title {
         font-size: 18px;
@@ -129,24 +124,24 @@
 }
 
 @mixin alert-error {
-  @include alert-box($red-fill, $red-stroke-weak, $red-text); 
+  @include alert-box($red-fill, $red-stroke-weak, $red-text);
 }
 
 @mixin alert-success {
-  @include alert-box($green-fill, $green-stroke-weak, $green-text); 
+  @include alert-box($green-fill, $green-stroke-weak, $green-text);
 }
 
 @mixin alert-info {
-  @include alert-box($brand-fill, $brand-stroke-weak, $brand-text); 
+  @include alert-box($brand-fill, $brand-stroke-weak, $brand-text);
 }
 
 @mixin alert-warning {
-  @include alert-box($amber-fill, $amber-stroke-weak, $amber-text); 
+  @include alert-box($amber-fill, $amber-stroke-weak, $amber-text);
 }
 
 //feature cards
 @mixin feature-card {
-  @include flex($direction: column, $align:flex-start, $gap: 1rem);
+  @include flex($direction: column, $align: flex-start, $gap: 1rem);
   padding: 1rem 1.5rem;
   border-radius: 4px;
   border: 1px solid $gray-fill;
@@ -156,26 +151,26 @@
     padding: 9px;
     width: 42px;
     height: 42px;
-    @include flex-center;
-    background-color: $brand-fill; 
-    color: $brand-text; 
+    @include flex(row, center, center);
+    background-color: $brand-fill;
+    color: $brand-text;
     border-radius: 50%;
   }
-  
+
   .card-title {
     @include typography(1.25rem, 1.5rem, 400);
     color: $gray-text-strong;
   }
-  
+
   .card-description {
-    @include h13; 
+    @include h13;
     color: $gray-stroke-strong;
   }
 }
 
 //feature cards
 @mixin feature-card {
-  @include flex($direction: column, $align:flex-start, $gap: 1rem);
+  @include flex($direction: column, $align: flex-start, $gap: 1rem);
   padding: 1rem 1.5rem;
   border-radius: 4px;
   border: 1px solid $gray-fill;
@@ -185,19 +180,19 @@
     padding: 9px;
     width: 42px;
     height: 42px;
-    @include flex-center;
-    background-color: $brand-fill; 
-    color: $brand-text; 
+    @include flex(row, center, center);
+    background-color: $brand-fill;
+    color: $brand-text;
     border-radius: 50%;
   }
-  
+
   .card-title {
     @include typography(1.25rem, 1.5rem, 400);
     color: $gray-text-strong;
   }
-  
+
   .card-description {
-    @include h13; 
+    @include h13;
     color: $gray-stroke-strong;
   }
 }

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -1,33 +1,3 @@
-@mixin flex-center {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-@mixin flex-column ($gap: 0) {
-  display: flex;
-  flex-direction: column;
-  gap: $gap;
-}
-
-@mixin flex-row {
-  display: flex;
-  align-items: center;
-  flex-direction: row;
-}
-
-@mixin flex-between {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-@mixin flex-row-center {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
 @mixin flex($direction: row, $justify: flex-start, $align: stretch, $gap: 0) {
   display: flex;
   flex-direction: $direction;
@@ -42,16 +12,6 @@
   }
 }
 
-@mixin flex-row-center {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-@mixin flex-row {
-  display: flex;
-  align-items: center;
-  flex-direction: row;
-}
 
 @mixin tablet {
   @media (min-width: 768px) {


### PR DESCRIPTION
This PR refactors our SCSS utility mixins for flexbox. It deprecates and removes several single-purpose mixins (`@flex-row`, `@flex-column`, `@flex-center`, etc) and replaces them with a single, more reusable, and flexible `@flex()` mixin.

## Why This Change?
The previous approach led to code duplication and was not very flexible. If we needed a new variation (e.g., "flex-row-space-between"), we would have had to create another mixin.

**Consolidating into a single `@flex()` mixin:**

- **Improves Maintainability**: All flexbox logic is in one place.

- **Reduces Code Duplication**: We've removed redundant code.

- **Increases Flexibility**: The new mixin can handle all flexbox variations with arguments.

## How This Was Implemented

1. Created _mixins.scss: A new, robust @flex() mixin that accepts arguments for direction, align, justify, etc.
2. **Replaced Instances:** Searched the codebase and replaced all instances of the old mixins:

- `@flex-row` was replaced with `@flex(direction: row)`

- `@flex-column` was replaced with `@flex(direction: column)`

- `@flex-center` was replaced with `@flex(direction: row, align: center, justify: center)` 

3. **Removed Old Mixins**: The deprecated `@flex-row`, `@flex-column`, and `@flex-center` mixins have been deleted.