### PR TITLE
chore(GSDT 354): fix husky script execution

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-npx --no -- commitlint --edit $1
+npx --no-install commitlint --edit "$1"

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,1 @@
-export default { extends: ['@commitlint/config-conventional'] };
+module.exports = { extends: ['@commitlint/config-conventional'] };


### PR DESCRIPTION
### Summary

Fixes an issue where the `.husky/commit-msg` hook could not execute due to incorrect file permissions, causing commit linting to fail.

### Changes

-   Updated Husky commit-msg hook permissions

-   Ensured script runs correctly during pre-commit checks

### Notes

This resolves the `cannot execute binary file (code 126)` error during commits.