### PR TITLE
feat(GSDT 358): Resolve email verification redirect loop and onboarding failure

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,5 +1,5 @@
 import { Routes } from '@angular/router';
-import { authGuard, guestGuard, onboardingGuard } from '@app/core';
+import { authGuard, guestGuard, onboardingGuard, emailVerificationGuard } from '@app/core';
 
 export const routes: Routes = [
   {
@@ -36,7 +36,7 @@ export const routes: Routes = [
       },
       {
         path: 'email-verification',
-        canActivate: [guestGuard],
+        canActivate: [emailVerificationGuard],
         loadComponent: () =>
           import('./features/email-verification/email-verification').then(
             (c) => c.EmailVerification,

--- a/src/app/core/guards/email-verification-guard.spec.ts
+++ b/src/app/core/guards/email-verification-guard.spec.ts
@@ -1,0 +1,105 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  CanActivateFn,
+  Router,
+  ActivatedRouteSnapshot,
+  RouterStateSnapshot,
+} from '@angular/router';
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { emailVerificationGuard } from './email-verification-guard';
+import { User, UserState, UserRole, PremiumTier } from '../models/auth.model';
+import { selectCurrentUser, selectIsAuthenticated } from '@app/store/auth/auth.selectors';
+import { APP_CONSTANTS } from '../constants/app.constants';
+
+describe('emailVerificationGuard', () => {
+  let store: MockStore;
+  let router: Router;
+
+  const dummyRoute = {} as ActivatedRouteSnapshot;
+  const dummyState = {} as RouterStateSnapshot;
+  const { APP_ROUTES, FULL_PAGE_ROUTES } = APP_CONSTANTS;
+
+  const executeGuard: CanActivateFn = (...guardParameters) =>
+    TestBed.runInInjectionContext(() => emailVerificationGuard(...guardParameters));
+
+  const createMockUser = (overrides: Partial<User>): User => {
+    const defaultUser: User = {
+      id: '1',
+      email: 'test@example.com',
+      username: 'Test User',
+      role: UserRole.USER,
+      state: UserState.REGISTERED,
+      isVerified: false,
+      premiumTier: PremiumTier.FREE,
+      language: 'en',
+      timezone: 'UTC',
+      updatedAt: new Date().toISOString(),
+      lastLoginAt: new Date().toISOString(),
+    };
+    return { ...defaultUser, ...overrides };
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideMockStore({
+          initialState: {},
+          selectors: [
+            { selector: selectCurrentUser, value: null },
+            { selector: selectIsAuthenticated, value: false },
+          ],
+        }),
+        {
+          provide: Router,
+          useValue: {
+            navigateByUrl: jest.fn(),
+          },
+        },
+      ],
+    });
+
+    store = TestBed.inject(MockStore);
+    router = TestBed.inject(Router);
+  });
+
+  it('should be created', () => {
+    expect(executeGuard).toBeTruthy();
+  });
+
+  it('should BLOCK and redirect to login if user is not authenticated', () => {
+    const result = executeGuard(dummyRoute, dummyState);
+
+    expect(router.navigateByUrl).toHaveBeenCalledWith(APP_ROUTES.LOGIN);
+    expect(result).toBe(false);
+  });
+
+  it('should BLOCK and redirect to interest selection if user is already verified', () => {
+    store.overrideSelector(selectIsAuthenticated, true);
+    store.overrideSelector(
+      selectCurrentUser,
+      createMockUser({
+        isVerified: true,
+      }),
+    );
+
+    const result = executeGuard(dummyRoute, dummyState);
+
+    expect(router.navigateByUrl).toHaveBeenCalledWith(FULL_PAGE_ROUTES.INTEREST_SELECTION);
+    expect(result).toBe(false);
+  });
+
+  it('should ALLOW access if user is authenticated but not verified', () => {
+    store.overrideSelector(selectIsAuthenticated, true);
+    store.overrideSelector(
+      selectCurrentUser,
+      createMockUser({
+        isVerified: false,
+      }),
+    );
+
+    const result = executeGuard(dummyRoute, dummyState);
+
+    expect(router.navigateByUrl).not.toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
+});

--- a/src/app/core/guards/email-verification-guard.ts
+++ b/src/app/core/guards/email-verification-guard.ts
@@ -1,0 +1,27 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { Store } from '@ngrx/store';
+import * as AuthSelectors from '@app/store/auth/auth.selectors';
+import { AppState } from '@app/store/app.state';
+import { APP_CONSTANTS } from '../constants/app.constants';
+
+export const emailVerificationGuard: CanActivateFn = () => {
+  const store = inject(Store<AppState>);
+  const router = inject(Router);
+  const { APP_ROUTES, FULL_PAGE_ROUTES } = APP_CONSTANTS;
+
+  const user = store.selectSignal(AuthSelectors.selectCurrentUser)();
+  const isAuthenticated = store.selectSignal(AuthSelectors.selectIsAuthenticated)();
+
+  if (!isAuthenticated || !user) {
+    router.navigateByUrl(APP_ROUTES.LOGIN);
+    return false;
+  }
+
+  if (user.isVerified) {
+    router.navigateByUrl(FULL_PAGE_ROUTES.INTEREST_SELECTION);
+    return false;
+  }
+
+  return true;
+};

--- a/src/app/core/index.ts
+++ b/src/app/core/index.ts
@@ -12,6 +12,7 @@ export * from './interceptors/global-http-error-interceptor';
 export * from './guards/auth-guard';
 export * from './guards/onboarding-guard';
 export * from './guards/guest-guard';
+export * from './guards/email-verification-guard';
 
 // constants
 export * from './constants/app.constants';

--- a/src/app/features/level-selection/level-selection.ts
+++ b/src/app/features/level-selection/level-selection.ts
@@ -16,7 +16,11 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { OnboardingDataService, SkillLevel, UserSkill } from '@app/core';
 import { selectIsCompletingOnboarding } from '@app/store/auth/auth.selectors';
-import { completeOnboarding, completeOnboardingSuccess } from '@app/store/auth/auth.actions';
+import {
+  completeOnboarding,
+  completeOnboardingFailure,
+  completeOnboardingSuccess,
+} from '@app/store/auth/auth.actions';
 import { SkillLevelSelectorComponent } from '@app/shared/compomonents/skill-level-selector/skill-level-selector';
 import { APP_CONSTANTS } from '@app/core';
 
@@ -142,6 +146,11 @@ export class LevelSelection implements OnInit, OnDestroy {
       .subscribe(() => {
         this.isComplete.set(true);
         this.celebrate();
+      });
+    this.actions$
+      .pipe(ofType(completeOnboardingFailure), takeUntilDestroyed(this.destroyRef))
+      .subscribe(({ error }) => {
+        this.router.navigateByUrl(FULL_PAGE_ROUTES.INTEREST_SELECTION);
       });
   }
 


### PR DESCRIPTION
**Related Ticket**: Closes [[GSDT-358](https://amali-tech.atlassian.net/jira/software/projects/GSDT/boards/2181/backlog?selectedIssue=GSDT-358)]

This PR fixes a critical bug that caused an infinite redirect loop for newly registered users.

Root Cause: The `/email-verification` route was incorrectly protected by the `GuestGuard`. When a new, authenticated (but unverified) user was sent to this page, the `GuestGuard` saw they were authenticated and tried to redirect them away, creating a loop.

**Solution**: This PR creates a new, dedicated `EmailVerificationGuard` that contains the correct logic for this specific route.

### Changes Made

1. `fix(auth): create EmailVerificationGuard to fix redirect loop`

- Created `email-verification.guard.ts` with logic to handle all three user states (unauthenticated, authenticated/verified, authenticated/unverified).

- Created `email-verification.guard.spec.ts` with 100% test coverage for all guard paths.

- Updated the routing module to protect `/email-verification` with the new `EmailVerificationGuard` (and removed `GuestGuard` from it).

2 `fix(onboarding): redirect user to interest selection screen on completeOnboardingFailure`

- While testing, I found a related bug. This commit fixes an issue where a user was not redirected correctly if the completeOnboarding action failed. They are now correctly sent back to the /onboarding/interests-selection screen.

### How to Test
Please verify the new guard logic by testing these 3 scenarios:

1. **As a NOT Authenticated (Guest) user:**

- [ ] Go directly to `/email-verification`.

- [ ] **Expected**: You are immediately blocked and redirected to /`login`.

2. **As an Authenticated AND Verified user (e.g., an existing user):**

- [ ] Log in and try to go directly to `/email-verification`.

- [ ] **Expected**: You are blocked (you're already verified) and redirected to /onboarding/interests-selection or /dashboard.

3. As an Authenticated, UNVERIFIED user (The Bug Case):

- [ ] Register a brand new user.

- [ ] **Expected**: You are successfully redirected to `/email-verification` and can see the page. The infinite loop is gone.