### PR TITLE
feat(GSDT 361): build stat cards section

### DIFF
--- a/src/app/core/icons/index.ts
+++ b/src/app/core/icons/index.ts
@@ -10,6 +10,9 @@ import {
   BellDot,
   Menu,
   X,
+  Flame,
+  ClipboardCheck,
+  BrainCircuit,
 } from 'lucide-angular';
 
 export const appIcons = {
@@ -24,4 +27,7 @@ export const appIcons = {
   BellDot,
   Menu,
   X,
+  Flame,
+  ClipboardCheck,
+  BrainCircuit,
 };

--- a/src/app/features/dashboard/dashboard.html
+++ b/src/app/features/dashboard/dashboard.html
@@ -1,1 +1,11 @@
-<p>dashboard works!</p>
+<header class="dashboard-header">
+  <h1>Welcome, Aba 👋</h1>
+  <p>Track your progress and continue developing your skill</p>
+</header>
+<section class="stats-grid">
+  <app-stat-card title="Current Streak" [value]="4 + ' days'" [iconName]="'flame'"></app-stat-card>
+
+  <app-stat-card title="Task Completed" [value]="2" iconName="clipboard-check"></app-stat-card>
+
+  <app-stat-card title="Skills In Progress" [value]="1" iconName="brain-circuit"></app-stat-card>
+</section>

--- a/src/app/features/dashboard/dashboard.scss
+++ b/src/app/features/dashboard/dashboard.scss
@@ -1,0 +1,55 @@
+@use 'typography' as *;
+@use 'mixins' as *;
+
+:host {
+  display: block;
+  background-color: var(--color-background-white);
+}
+
+.dashboard-header {
+  padding: var(--space-md);
+
+  h1 {
+    @include h10;
+    color: var(--color-gray-text-strong);
+    margin-bottom: var(--space-sm);
+  }
+  p {
+    @include h13;
+    color: var(--color-gray-stroke-strong);
+  }
+}
+
+.stats-grid {
+  @include flex($direction: row, $gap: var(--space-md));
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  padding: 0 var(--space-md);
+
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  app-stat-card {
+    flex: 0 0 80%;
+    scroll-snap-align: end;
+  }
+}
+
+@include tablet {
+  .dashboard-header {
+    padding: 2.5rem 3rem;
+
+    h1 {
+      font-size: 2rem;
+      font-weight: 600;
+    }
+  }
+  .stats-grid {
+    @include grid($columns: 3, $gap: var(--space-md));
+    margin-bottom: 2.5rem;
+    padding: 0 3rem;
+  }
+}

--- a/src/app/features/dashboard/dashboard.spec.ts
+++ b/src/app/features/dashboard/dashboard.spec.ts
@@ -3,11 +3,14 @@ import { Router } from '@angular/router';
 import { ShepherdService } from 'angular-shepherd';
 import { provideMockStore, MockStore } from '@ngrx/store/testing';
 import { ChangeDetectionStrategy } from '@angular/core';
+import { importProvidersFrom } from '@angular/core';
+import { LucideAngularModule } from 'lucide-angular';
 
 import { Dashboard } from './dashboard';
 import { AppState } from '@app/store/app.state';
 import { selectCurrentUser } from '@app/store/auth/auth.selectors';
 import { User, UserRole, UserState, TourGuide, PremiumTier } from '@app/core';
+import { appIcons } from '@app/core';
 
 jest.mock('./dashboard.config', () => ({
   defaultStepOptions: {},
@@ -62,6 +65,7 @@ describe('Dashboard', () => {
             },
           ],
         }),
+        importProvidersFrom(LucideAngularModule.pick(appIcons)),
       ],
     })
       .overrideComponent(Dashboard, {

--- a/src/app/features/dashboard/dashboard.ts
+++ b/src/app/features/dashboard/dashboard.ts
@@ -9,10 +9,11 @@ import { selectCurrentUser } from '@app/store/auth/auth.selectors';
 
 import { getSteps as defaultSteps, defaultStepOptions } from './dashboard.config';
 import { TourGuide } from '@app/core';
+import { StatCard } from '@app/shared';
 
 @Component({
   selector: 'app-dashboard',
-  imports: [LucideAngularModule],
+  imports: [LucideAngularModule, StatCard],
   templateUrl: './dashboard.html',
   styleUrl: './dashboard.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/shared/components/app-icon/app-icon.html
+++ b/src/app/shared/components/app-icon/app-icon.html
@@ -1,0 +1,1 @@
+<lucide-icon [name]="name" [size]="size" [color]="color" [strokeWidth]="strokeWidth" />

--- a/src/app/shared/components/app-icon/app-icon.spec.ts
+++ b/src/app/shared/components/app-icon/app-icon.spec.ts
@@ -1,0 +1,42 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { importProvidersFrom } from '@angular/core';
+import { LucideAngularModule, Home, User, Settings } from 'lucide-angular';
+import { AppIcon } from './app-icon';
+
+describe('AppIcon', () => {
+  let component: AppIcon;
+  let fixture: ComponentFixture<AppIcon>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AppIcon],
+      providers: [
+        importProvidersFrom(
+          LucideAngularModule.pick({
+            Home,
+            User,
+            Settings,
+          }),
+        ),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AppIcon);
+    component = fixture.componentInstance;
+  });
+
+  it('should create the component', () => {
+    component.name = 'home';
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should render the real <lucide-icon> component', () => {
+    component.name = 'home';
+    fixture.detectChanges();
+
+    const lucideIconElement = fixture.debugElement.query(By.css('lucide-icon'));
+    expect(lucideIconElement).not.toBeNull();
+  });
+});

--- a/src/app/shared/components/app-icon/app-icon.ts
+++ b/src/app/shared/components/app-icon/app-icon.ts
@@ -1,0 +1,15 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { LucideAngularModule } from 'lucide-angular';
+
+@Component({
+  selector: 'app-icon',
+  imports: [LucideAngularModule],
+  templateUrl: './app-icon.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AppIcon {
+  @Input({ required: true }) public name!: string;
+  @Input() public size: number = 24;
+  @Input() public color: string = 'currentColor';
+  @Input() public strokeWidth: number = 1.5;
+}

--- a/src/app/shared/components/stat-card/stat-card.html
+++ b/src/app/shared/components/stat-card/stat-card.html
@@ -1,0 +1,11 @@
+<div class="stat-card-container">
+  <div class="stat-card-icon">
+    @if (iconName) {
+      <app-icon [name]="iconName" [size]="iconSize" />
+    }
+  </div>
+  <div class="stat-card-content">
+    <span class="stat-card-title">{{ title }}</span>
+    <span class="stat-card-value">{{ value }}</span>
+  </div>
+</div>

--- a/src/app/shared/components/stat-card/stat-card.scss
+++ b/src/app/shared/components/stat-card/stat-card.scss
@@ -1,0 +1,59 @@
+@use 'mixins' as *;
+@use 'typography' as *;
+
+$card-value: #3d3d3d;
+
+:host {
+  display: block;
+  height: 100%;
+}
+
+.stat-card-container {
+  @include flex($direction: row, $align: center, $gap: var(--space-xs));
+  padding: var(--space-lg, --space-md);
+  background-color: var(--color-white);
+  border: none;
+  border-radius: var(--rounded-xs);
+  height: 100%;
+}
+
+.stat-card-icon {
+  @include flex($direction: row, $justify: center, $align: center);
+  width: 32px;
+  height: 32px;
+  min-width: 32px;
+  border-radius: 50%;
+
+  background-color: var(--color-brand-fill);
+  color: var(--color-brand-text);
+}
+
+.stat-card-content {
+  @include flex($direction: column, $gap: 4px);
+}
+
+.stat-card-title {
+  font-size: 0.875rem;
+  font-weight: 400;
+  color: var(--color-gray-stroke-strong);
+  line-height: 20px;
+}
+
+.stat-card-value {
+  @include h13;
+  color: $card-value;
+}
+
+@include tablet {
+  .stat-card-container {
+    @include flex($direction: row, $align: center, $gap: 20px);
+  }
+  .stat-card-title {
+    @include h13;
+    font-weight: 400;
+  }
+
+  .stat-card-value {
+    @include h10;
+  }
+}

--- a/src/app/shared/components/stat-card/stat-card.spec.ts
+++ b/src/app/shared/components/stat-card/stat-card.spec.ts
@@ -1,0 +1,61 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { importProvidersFrom } from '@angular/core';
+import { LucideAngularModule, Flame, ClipboardCheck, BrainCircuit } from 'lucide-angular';
+import { StatCard } from './stat-card';
+
+describe('StatCard', () => {
+  let component: StatCard;
+  let fixture: ComponentFixture<StatCard>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [StatCard],
+      providers: [
+        importProvidersFrom(
+          LucideAngularModule.pick({
+            Flame,
+            ClipboardCheck,
+            BrainCircuit,
+          }),
+        ),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(StatCard);
+    component = fixture.componentInstance;
+  });
+
+  it('should create the component', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should render the title and value correctly', () => {
+    component.title = 'Current Streak';
+    component.value = '5 days';
+    fixture.detectChanges();
+
+    const titleEl = fixture.debugElement.query(By.css('.stat-card-title')).nativeElement;
+    const valueEl = fixture.debugElement.query(By.css('.stat-card-value')).nativeElement;
+
+    expect(titleEl.textContent).toContain('Current Streak');
+    expect(valueEl.textContent).toContain('5 days');
+  });
+
+  it('should not render lucide-icon if iconName is not provided', () => {
+    component.iconName = '';
+    fixture.detectChanges();
+
+    const iconDebugEl = fixture.debugElement.query(By.css('lucide-icon'));
+    expect(iconDebugEl).toBeNull();
+  });
+
+  it('should render lucide-icon when iconName is provided', () => {
+    component.iconName = 'flame';
+    fixture.detectChanges();
+
+    const iconDebugEl = fixture.debugElement.query(By.css('lucide-icon'));
+    expect(iconDebugEl).not.toBeNull();
+  });
+});

--- a/src/app/shared/components/stat-card/stat-card.ts
+++ b/src/app/shared/components/stat-card/stat-card.ts
@@ -1,0 +1,16 @@
+import { Component, ChangeDetectionStrategy, Input } from '@angular/core';
+import { LucideAngularModule } from 'lucide-angular';
+import { AppIcon } from '../app-icon/app-icon';
+@Component({
+  selector: 'app-stat-card',
+  imports: [LucideAngularModule, AppIcon],
+  templateUrl: './stat-card.html',
+  styleUrl: './stat-card.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class StatCard {
+  @Input() public title: string = '';
+  @Input() public value: string | number = '';
+  @Input() public iconName: string = '';
+  @Input() public iconSize: number = 24;
+}

--- a/src/app/shared/index.ts
+++ b/src/app/shared/index.ts
@@ -3,3 +3,4 @@ export * from './validators/custom-validators';
 export * from './input-field/input-field';
 export * from './components/dashboard-navigation/dashboard-navigation';
 export * from './components/dashboard-sidebar/dashboard-sidebar';
+export * from './components/stat-card/stat-card';

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,5 +1,6 @@
 @use 'styles/colors' as *;
 @use 'styles/mixins' as *;
+@use 'styles/variables' as *;
 @use 'styles/shepherd-theme';
 @import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap');
 
@@ -15,40 +16,50 @@
   --color-brand-stroke-weak: #{$brand-stroke-weak};
   --color-brand-fill: #{$brand-fill};
   --color-brand-fill-weak: #{$brand-fill-weak};
-
   --color-red-text: #{$red-text};
   --color-red-stroke-strong: #{$red-stroke-strong};
   --color-red-stroke-weak: #{$red-stroke-weak};
   --color-red-fill: #{$red-fill};
-
   --color-amber-text: #{$amber-text};
   --color-amber-text-strong: #{$amber-text-strong};
   --color-amber-stroke-strong: #{$amber-stroke-strong};
   --color-amber-stroke-weak: #{$amber-stroke-weak};
   --color-amber-fill: #{$amber-fill};
-
   --color-green-text: #{$green-text};
   --color-green-success: #{$green-success};
   --color-green-stroke-strong: #{$green-stroke-strong};
   --color-green-stroke-weak: #{$green-stroke-weak};
   --color-green-fill: #{$green-fill};
-
   --color-gray-text-strong: #{$gray-text-strong};
   --color-gray-text-weak: #{$gray-text-weak};
   --color-gray-stroke-strong: #{$gray-stroke-strong};
   --color-gray-stroke-weak: #{$gray-stroke-weak};
   --color-gray-fill: #{$gray-fill};
-
   --color-background-white: #{$background-white};
   --color-background-dark: #{$background-dark};
   --color-background-raised: #{$background-raised};
   --color-background-overlay: #{$background-overlay};
-
   --color-white: #{$white};
+
+  --space-xs: #{$space-xs};
+  --space-sm: #{$space-sm};
+  --space-md: #{$space-md};
+  --space-lg: #{$space-lg};
+  --space-xl: #{$space-xl};
+
+  --rounded-xs: #{$rounded-xs};
+  --rounded-sm: #{$rounded-sm};
+  --rounded-md: #{$rounded-md};
+  --rounded-lg: #{$rounded-lg};
+}
+
+html {
+  font-size: 16px;
 }
 
 body {
   font-family: 'Roboto', sans-serif;
+  font-size: 1rem;
 }
 
 a {

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -4,3 +4,14 @@ $z-layers: (
   'header': 20,
   'modal': 100,
 );
+
+$space-xs: 0.5rem;
+$space-sm: 0.75rem;
+$space-md: 1rem;
+$space-lg: 1.5rem;
+$space-xl: 2rem;
+
+$rounded-xs: 4px;
+$rounded-sm: 8px;
+$rounded-md: 12px;
+$rounded-lg: 16px;


### PR DESCRIPTION
**Related Ticket**: Closes [[GSDT-361](https://amali-tech.atlassian.net/browse/GSDT-361)]

This is the first UI feature for the new dashboard. This PR builds the reusable StatCardComponent and the responsive 3-column layout at the top of the page.

### Changes Made

**New "Dumb" Component:**

- Created `shared/components/stat-card` which is driven by `@Input` properties.

- Added styles to match the Figma design.

- Added unit tests (`.spec.ts`) for the new component.

**Layout Flow:**

- Implemented the responsive 3-column layout in `DashboardMainComponent`.

### 📸 Screenshot

<img width="2856" height="1558" alt="Screenshot 2025-11-07 at 04-22-14 SkillDev - Dashboard" src="https://github.com/user-attachments/assets/f605591f-74ef-4f0b-9f56-631b67dbebce" />

---

<img width="365" height="729" alt="Screenshot 2025-11-07 at 4 30 50 AM" src="https://github.com/user-attachments/assets/4f32e335-d492-4d82-a22c-741a3839ea43" />
