### PR TITLE
feat(GSDT 381): complete NgRx Store Setup for MCQ Generation Feature.

### DIFF
--- a/src/app/core/constants/app.constants.ts
+++ b/src/app/core/constants/app.constants.ts
@@ -28,5 +28,6 @@ export const APP_CONSTANTS = {
     UPDATE_TOUR_STATUS: '/users/tour-status',
     FORGOT_PASSWORD: '/auth/password/forgot',
     RESET_PASSWORD: '/auth/password/reset',
+    GENERATE_MCQ: '/api/v1/mcq/generate',
   },
 } as const;

--- a/src/app/core/models/mcq-model.ts
+++ b/src/app/core/models/mcq-model.ts
@@ -1,0 +1,28 @@
+export interface McqGenerationRequest {
+  userId: string;
+  interest: string;
+  difficulty: 'beginner' | 'intermediate' | 'advanced';
+  no_of_questions: number;
+}
+
+export interface McqQuestion {
+  question_number: string;
+  question_duration: number;
+  question_text: string;
+  options: string[];
+  hint: string;
+  correct_answer: string;
+  explanation: string;
+}
+
+export interface McqResponse {
+  success: boolean;
+  message: string;
+  data: {
+    mcqQuestion: McqQuestion[];
+  };
+  metadata: {
+    timestamp: string;
+    traceId: string;
+  };
+}

--- a/src/app/core/services/mcqs/mcq-service.ts
+++ b/src/app/core/services/mcqs/mcq-service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiService } from '../api/api-service';
+import { McqGenerationRequest, McqResponse } from '@app/core/models/mcq-model';
+
+import { APP_CONSTANTS } from '@app/core/constants/app.constants';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class McqGenerationService {
+  constructor(private readonly api: ApiService) {}
+
+  public generateQuiz(payload: McqGenerationRequest): Observable<McqResponse> {
+    return this.api.post<McqResponse>(APP_CONSTANTS.API_ENDPOINTS.GENERATE_MCQ, payload);
+  }
+}

--- a/src/app/store/mcqs/mcq.actions.ts
+++ b/src/app/store/mcqs/mcq.actions.ts
@@ -1,0 +1,19 @@
+import { createAction, props } from '@ngrx/store';
+import { McqGenerationRequest, McqResponse } from '@app/core/models/mcq-model';
+
+export const generateMcqQuiz = createAction(
+  '[MCQ] Generate MCQ Quiz',
+  props<{ request: McqGenerationRequest }>(),
+);
+
+export const generateMcqQuizSuccess = createAction(
+  '[MCQ API] Generate MCQ Quiz Success',
+  props<{ response: McqResponse }>(),
+);
+
+export const generateMcqQuizFailure = createAction(
+  '[MCQ API] Generate MCQ Quiz Failure',
+  props<{ error: string }>(),
+);
+
+export const clearMcqQuiz = createAction('[MCQ] Clear MCQ Quiz State');

--- a/src/app/store/mcqs/mcq.effects.ts
+++ b/src/app/store/mcqs/mcq.effects.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { of } from 'rxjs';
+import { catchError, map, switchMap } from 'rxjs/operators';
+import * as McqActions from './mcq.actions';
+import { McqGenerationService } from '@app/core/services/mcqs/mcq-service';
+
+@Injectable()
+export class McqGenerationEffects {
+  constructor(
+    private actions$: Actions,
+    private mcqService: McqGenerationService,
+  ) {}
+
+  public generateMcqQuiz$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(McqActions.generateMcqQuiz),
+
+      switchMap((action) =>
+        this.mcqService.generateQuiz(action.request).pipe(
+          map((response) => McqActions.generateMcqQuizSuccess({ response })),
+
+          catchError((error) => {
+            const errorMessage =
+              error.error?.message ||
+              error.message ||
+              'An unknown error occurred while generating the quiz.';
+            return of(
+              McqActions.generateMcqQuizFailure({
+                error: errorMessage,
+              }),
+            );
+          }),
+        ),
+      ),
+    ),
+  );
+}

--- a/src/app/store/mcqs/mcq.reducer.ts
+++ b/src/app/store/mcqs/mcq.reducer.ts
@@ -1,0 +1,42 @@
+import { createReducer, on } from '@ngrx/store';
+import * as McqActions from './mcq.actions';
+import { initialMcqGenerationState, McqGenerationState } from './mcq.state';
+
+export const mcqGenerationReducer = createReducer(
+  initialMcqGenerationState,
+
+  on(
+    McqActions.generateMcqQuiz,
+    (state): McqGenerationState => ({
+      ...state,
+      loading: true,
+      error: null,
+      questions: null,
+    }),
+  ),
+
+  on(
+    McqActions.generateMcqQuizSuccess,
+    (state, { response }): McqGenerationState => ({
+      ...state,
+      questions: response.data.mcqQuestion,
+      loading: false,
+    }),
+  ),
+
+  on(
+    McqActions.generateMcqQuizFailure,
+    (state, { error }): McqGenerationState => ({
+      ...state,
+      error,
+      loading: false,
+    }),
+  ),
+
+  on(
+    McqActions.clearMcqQuiz,
+    (): McqGenerationState => ({
+      ...initialMcqGenerationState,
+    }),
+  ),
+);

--- a/src/app/store/mcqs/mcq.selectors.ts
+++ b/src/app/store/mcqs/mcq.selectors.ts
@@ -13,7 +13,7 @@ export const selectMcqLoading = createSelector(selectMcqGenerationState, (state)
 export const selectMcqError = createSelector(selectMcqGenerationState, (state) => state.error);
 
 export const selectMcqTotalTime = createSelector(selectMcqQuestions, (questions) => {
-  if (!questions || questions.length === 0) {
+  if (!questions || !questions.length ) {
     return 0;
   }
   return questions.reduce((total, q) => total + q.question_duration, 0);

--- a/src/app/store/mcqs/mcq.selectors.ts
+++ b/src/app/store/mcqs/mcq.selectors.ts
@@ -1,0 +1,20 @@
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { McqGenerationState } from './mcq.state';
+
+export const selectMcqGenerationState = createFeatureSelector<McqGenerationState>('mcqGeneration');
+
+export const selectMcqQuestions = createSelector(
+  selectMcqGenerationState,
+  (state) => state.questions,
+);
+
+export const selectMcqLoading = createSelector(selectMcqGenerationState, (state) => state.loading);
+
+export const selectMcqError = createSelector(selectMcqGenerationState, (state) => state.error);
+
+export const selectMcqTotalTime = createSelector(selectMcqQuestions, (questions) => {
+  if (!questions || questions.length === 0) {
+    return 0;
+  }
+  return questions.reduce((total, q) => total + q.question_duration, 0);
+});

--- a/src/app/store/mcqs/mcq.state.ts
+++ b/src/app/store/mcqs/mcq.state.ts
@@ -1,0 +1,13 @@
+import { McqQuestion } from '@app/core/models/mcq-model';
+
+export interface McqGenerationState {
+  questions: McqQuestion[] | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export const initialMcqGenerationState: McqGenerationState = {
+  questions: null,
+  loading: false,
+  error: null,
+};


### PR DESCRIPTION
**Summary**

This PR introduces the full NgRx feature store (mcqGeneration) and the corresponding side effects layer for the Multiple Choice Question (MCQ) component. It decouples the data management and API interaction logic from the component, establishing a clean, testable source of truth for all quiz data.

This move prepares the application to fully utilize the backend API instead of relying on mock data.

**Key Changes**

- A new feature store slice named mcqGeneration is implemented, covering the standard NgRx architecture components:

- Models (mcq-generation-model.ts): Defines the strict type contracts for the API Request (McqGenerationRequest) and the expected API Response (McqResponse containing McqQuestion arrays).

- State (mcq-generation.state.ts): Defines the shape of the store slice, including questions, loading, and error.

- Actions (mcq-generation.actions.ts): Defines actions for the feature lifecycle: generateMcqQuiz, generateMcqQuizSuccess, generateMcqQuizFailure, and clearMcqQuiz.

- Reducer (mcq-generation.reducer.ts): Handles state transitions based on actions, managing the loading status and storing the fetched questions or any resulting error messages.
- Selectors (mcq-generation.selectors.ts): Provides methods to easily retrieve data (e.g., selectMcqQuestions, selectMcqLoading, and a derived selector selectMcqTotalTime).
- Service (mcq-generation-service.ts): Contains the dedicated HTTP POST logic for calling the /api/v1/mcq/generate endpoint.

- Effects (mcq-generation.effects.ts): Listens to the generateMcqQuiz action, orchestrates the call to the service, and handles success/failure by dispatching appropriate actions.


**Next Step**

The MultipleChoice component (multiple-choice.ts) is currently still reading from mock data. The next step is a follow-up PR/commit to refactor that component to:

Inject the NgRx Store.

Use the new selectors to subscribe to the actual quiz data and loading/error states.

Dispatch the generateMcqQuiz action to request a quiz from the backend.