### PR TITLE
fix(GSDT 408): disable resend code button until countdown ends 

### DIFF
--- a/src/app/features/email-verification/email-verification.scss
+++ b/src/app/features/email-verification/email-verification.scss
@@ -92,6 +92,11 @@
     color: $brand-text;
     cursor: pointer;
 
+    &:disabled {
+      cursor: not-allowed;
+      color: $brand-stroke-weak;
+    }
+
     @include tablet {
       @include h11;
     }

--- a/src/app/features/email-verification/email-verification.scss
+++ b/src/app/features/email-verification/email-verification.scss
@@ -3,8 +3,11 @@
 @use 'colors' as *;
 @use 'components' as *;
 
+$total-padding: 4rem;
+
 .verification-container {
   @include flex(row, center, center);
+  min-height: calc(100vh - $total-padding);
 }
 
 .card {


### PR DESCRIPTION
### **Description**

This PR improves the **email verification screen** by:

-   Disabling the **resend email button** until the countdown finishes

-   Updating the button's disabled state with a `not-allowed` cursor and weaker color tone

-   Centering the entire verification container vertically using a calculated `min-height` for consistent spacing across devices

### **Changes Made**

-   Added `:disabled` styles in SCSS for button state feedback

-   Adjusted layout with `flex` and `min-height: calc(100vh - $total-padding)`

-   Ensured visual alignment and responsiveness

### **Testing**

1.  Open the email verification page.

2.  Observe that the resend button is **disabled** and shows the correct cursor until the countdown ends.

3.  Confirm the container remains vertically centered across all screen sizes.

<img width="1920" height="1031" alt="Screenshot (98)" src="https://github.com/user-attachments/assets/01a383e5-9e40-4519-9f5f-3ca5e4cb2580" />
