### PR TITLE
fix(GSDT 413): add routing logic for pricing plan selection and navigation

### DIFF
--- a/src/app/features/landing-page/components/pricing-models/pricing-card/pricing-card.html
+++ b/src/app/features/landing-page/components/pricing-models/pricing-card/pricing-card.html
@@ -6,11 +6,11 @@
 @let isPopular = plan().isPopular;
 
 <article class="pricing-card" [class.is-popular]="isPopular">
-  @if (isPopular){
-  <div class="popular-tag-wrapper">
-    <div class="popular-tag">Most Popular </div>
-    <img src="assets/stars.png" alt="Stars emoji" class="popular-stars">
-  </div>
+  @if (isPopular) {
+    <div class="popular-tag-wrapper">
+      <div class="popular-tag">Most Popular</div>
+      <img src="assets/stars.png" alt="Stars emoji" class="popular-stars" />
+    </div>
   }
 
   <div class="card-content-wrapper">
@@ -20,23 +20,21 @@
     </header>
 
     <div class="price-container">
-      <span class="price-value">{{ price | currency:'USD':'symbol':'1.0-2' }}</span>
+      <span class="price-value">{{ price | currency: 'USD' : 'symbol' : '1.0-2' }}</span>
       <span class="price-period">{{ period }}</span>
     </div>
-
-
 
     <ul class="features-list">
       <h4 class="features-title">What you get</h4>
       @for (feature of features; track $index) {
-      <li class="feature-item">
-        <img [src]="icon" alt="Checkmark icon" class="feature-icon">
-        <span>{{ feature }}</span>
-      </li>
+        <li class="feature-item">
+          <img [src]="icon" alt="Checkmark icon" class="feature-icon" />
+          <span>{{ feature }}</span>
+        </li>
       }
     </ul>
 
-    <button class="action-button" aria-label="Select {{ name }} plan">
+    <button class="action-button" aria-label="Select {{ name }} plan" (click)="onSelectPlan()">
       I want this!
     </button>
   </div>

--- a/src/app/features/landing-page/components/pricing-models/pricing-card/pricing-card.ts
+++ b/src/app/features/landing-page/components/pricing-models/pricing-card/pricing-card.ts
@@ -1,10 +1,12 @@
 import { CurrencyPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { Router } from '@angular/router';
+import { APP_CONSTANTS } from '@app/core/constants/app.constants';
 
 export interface PricingPlan {
   name: string;
   tagline: string;
-  price: number; 
+  price: number;
   period: string;
   isPopular: boolean;
   features: string[];
@@ -15,9 +17,32 @@ export interface PricingPlan {
   imports: [CurrencyPipe],
   templateUrl: './pricing-card.html',
   styleUrl: './pricing-card.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PricingCard {
-  public icon = 'assets/blue-checkmark.png'
+  constructor(private router: Router) {}
+
+  public icon = 'assets/blue-checkmark.png';
   public plan = input.required<PricingPlan>();
+
+  public onSelectPlan(): void {
+    const planName = this.plan().name;
+    let planId: number;
+
+    switch (planName) {
+      case 'Free Plan':
+        planId = 1;
+        break;
+      case 'Pro':
+        planId = 2;
+        break;
+      case 'Elite':
+        planId = 3;
+        break;
+      default:
+        planId = 1;
+    }
+
+    this.router.navigateByUrl(`${APP_CONSTANTS.FULL_PAGE_ROUTES.PLAN_CONFIRMATION}/${planId}`);
+  }
 }


### PR DESCRIPTION
### **Description:**

This PR implements the logic that allows users to navigate to the correct plan confirmation page when selecting a pricing plan (Free, Pro, or Elite). Each button click dynamically routes the user to the appropriate confirmation route based on the selected plan.

* * * * *

### **Changes Include:**

-   Added `onSelectPlan()` logic to handle navigation by plan type.

-   Updated pricing card template to include onSelectPlan() for click event.

* * * * *

### **How to Test:**

1.  Navigate to the **Pricing Page**.

2.  Click the "I want this!" button on each plan.

3.  Confirm that each plan redirects to the correct route:

    -   Free Plan → `/plan-confirmation/1`

    -   Pro Plan → `/plan-confirmation/2`

    -   Elite Plan → `/plan-confirmation/3`
    
    
<img width="1269" height="836" alt="Screenshot 2025-11-01 094022" src="https://github.com/user-attachments/assets/4dbb8d76-1062-4ad4-938f-80dc8ac8ca2d" />
