### PR TITLE
feat(GSDT 411): implement Secure NgRx State Persistence (Re-hydration)

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,5 +1,8 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { AppState } from './store/app.state';
+import { checkAuthSession } from './store/auth/auth.actions';
 import { Toast } from './shared/compomonents/toast/toast';
 
 @Component({
@@ -9,4 +12,10 @@ import { Toast } from './shared/compomonents/toast/toast';
   styleUrl: './app.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class App {}
+export class App implements OnInit {
+  constructor(private store: Store<AppState>) {}
+
+  ngOnInit(): void {
+    this.store.dispatch(checkAuthSession());
+  }
+}

--- a/src/app/core/constants/app.constants.ts
+++ b/src/app/core/constants/app.constants.ts
@@ -30,5 +30,6 @@ export const APP_CONSTANTS = {
     FORGOT_PASSWORD: '/auth/password/forgot',
     RESET_PASSWORD: '/auth/password/reset',
     GENERATE_MCQ: '/api/v1/mcq/generate',
+    PROFILE: '/users/profile/me',
   },
 } as const;

--- a/src/app/core/services/auth/auth-service.ts
+++ b/src/app/core/services/auth/auth-service.ts
@@ -71,4 +71,8 @@ export class AuthService {
     const params = new HttpParams().set('email', email);
     return this.api.post<UserResponse>(API_ENDPOINTS.UPDATE_TOUR_STATUS, null, { params });
   }
+
+  public getUserProfile(): Observable<UserResponse> {
+    return this.api.get<UserResponse>(API_ENDPOINTS.PROFILE);
+  }
 }

--- a/src/app/store/auth/auth.actions.ts
+++ b/src/app/store/auth/auth.actions.ts
@@ -22,7 +22,7 @@ export const registerUserSuccess = createAction(
 
 export const registerUserFailure = createAction(
   '[Auth/Registration] Register User Failure',
-  props<{ error: AppError }>(),
+  props<{ error: AppError; silent?: boolean }>(),
 );
 
 export const login = createAction('[Auth/Login] Login', props<{ request: LoginRequest }>());
@@ -31,7 +31,7 @@ export const loginSuccess = createAction('[Auth/Login] Login Success', props<{ u
 
 export const loginFailure = createAction(
   '[Auth/Login] Login Failure',
-  props<{ error: AppError }>(),
+  props<{ error: AppError; silent?: boolean }>(),
 );
 
 export const logout = createAction('[Auth/Logout] Logout');
@@ -40,7 +40,7 @@ export const logoutSuccess = createAction('[Auth/Logout] Logout Success');
 
 export const logoutFailure = createAction(
   '[Auth/Logout] Logout Failure',
-  props<{ error: AppError }>(),
+  props<{ error: AppError; silent?: boolean }>(),
 );
 
 export const verifyEmailOtp = createAction(
@@ -55,7 +55,7 @@ export const verifyEmailOtpSuccess = createAction(
 
 export const verifyEmailOtpFailure = createAction(
   '[Auth/Verification] Verify Email OTP Failure',
-  props<{ error: AppError }>(),
+  props<{ error: AppError; silent?: boolean }>(),
 );
 
 export const completeOnboarding = createAction(
@@ -70,7 +70,7 @@ export const completeOnboardingSuccess = createAction(
 
 export const completeOnboardingFailure = createAction(
   '[Onboarding] Complete Onboarding Failure',
-  props<{ error: AppError }>(),
+  props<{ error: AppError; silent?: boolean }>(),
 );
 
 export const socialLogin = createAction(
@@ -85,7 +85,7 @@ export const socialLoginSuccess = createAction(
 
 export const socialLoginFailure = createAction(
   '[Auth/Social] Social Login Failure',
-  props<{ error: AppError }>(),
+  props<{ error: AppError; silent?: boolean }>(),
 );
 
 export const resendVerification = createAction(
@@ -100,8 +100,9 @@ export const resendVerificationSuccess = createAction(
 
 export const resendVerificationFailure = createAction(
   '[Auth/Verification] Resend Verification Failure',
-  props<{ error: AppError }>(),
+  props<{ error: AppError; silent?: boolean }>(),
 );
+
 export const forgotPassword = createAction(
   '[Auth/Password Reset] Forgot Password',
   props<{ request: UserEmailRequest }>(),
@@ -120,9 +121,10 @@ export const forgotPasswordFailure = createAction(
 export const resetPasswordResetState = createAction(
   '[Auth/Password Reset] Reset Password Reset State',
 );
+
 export const resetPassword = createAction(
   '[Auth/Password] Reset Password',
-  props<{ request: ResetPasswordRequest }>(),
+  props<{ request: ResetPasswordRequest; silent?: boolean }>(),
 );
 
 export const resetPasswordSuccess = createAction(
@@ -132,7 +134,7 @@ export const resetPasswordSuccess = createAction(
 
 export const resetPasswordFailure = createAction(
   '[Auth/Password] Reset Password Failure',
-  props<{ error: AppError }>(),
+  props<{ error: AppError; silent?: boolean }>(),
 );
 export const updateTourStatus = createAction('[Auth/Tour] Update Tour Status');
 
@@ -143,5 +145,5 @@ export const updateTourStatusSuccess = createAction(
 
 export const updateTourStatusFailure = createAction(
   '[Auth/Tour] Update Tour Status Failure',
-  props<{ error: AppError }>(),
+  props<{ error: AppError; silent?: boolean }>(),
 );

--- a/src/app/store/auth/auth.actions.ts
+++ b/src/app/store/auth/auth.actions.ts
@@ -22,7 +22,7 @@ export const registerUserSuccess = createAction(
 
 export const registerUserFailure = createAction(
   '[Auth/Registration] Register User Failure',
-  props<{ error: AppError; silent?: boolean }>(),
+  props<{ error: AppError }>(),
 );
 
 export const login = createAction('[Auth/Login] Login', props<{ request: LoginRequest }>());
@@ -31,7 +31,7 @@ export const loginSuccess = createAction('[Auth/Login] Login Success', props<{ u
 
 export const loginFailure = createAction(
   '[Auth/Login] Login Failure',
-  props<{ error: AppError; silent?: boolean }>(),
+  props<{ error: AppError }>(),
 );
 
 export const logout = createAction('[Auth/Logout] Logout');
@@ -40,7 +40,7 @@ export const logoutSuccess = createAction('[Auth/Logout] Logout Success');
 
 export const logoutFailure = createAction(
   '[Auth/Logout] Logout Failure',
-  props<{ error: AppError; silent?: boolean }>(),
+  props<{ error: AppError }>(),
 );
 
 export const verifyEmailOtp = createAction(
@@ -55,7 +55,7 @@ export const verifyEmailOtpSuccess = createAction(
 
 export const verifyEmailOtpFailure = createAction(
   '[Auth/Verification] Verify Email OTP Failure',
-  props<{ error: AppError; silent?: boolean }>(),
+  props<{ error: AppError }>(),
 );
 
 export const completeOnboarding = createAction(
@@ -70,7 +70,7 @@ export const completeOnboardingSuccess = createAction(
 
 export const completeOnboardingFailure = createAction(
   '[Onboarding] Complete Onboarding Failure',
-  props<{ error: AppError; silent?: boolean }>(),
+  props<{ error: AppError }>(),
 );
 
 export const socialLogin = createAction(
@@ -85,7 +85,7 @@ export const socialLoginSuccess = createAction(
 
 export const socialLoginFailure = createAction(
   '[Auth/Social] Social Login Failure',
-  props<{ error: AppError; silent?: boolean }>(),
+  props<{ error: AppError }>(),
 );
 
 export const resendVerification = createAction(
@@ -100,7 +100,7 @@ export const resendVerificationSuccess = createAction(
 
 export const resendVerificationFailure = createAction(
   '[Auth/Verification] Resend Verification Failure',
-  props<{ error: AppError; silent?: boolean }>(),
+  props<{ error: AppError }>(),
 );
 
 export const forgotPassword = createAction(
@@ -124,7 +124,7 @@ export const resetPasswordResetState = createAction(
 
 export const resetPassword = createAction(
   '[Auth/Password] Reset Password',
-  props<{ request: ResetPasswordRequest; silent?: boolean }>(),
+  props<{ request: ResetPasswordRequest }>(),
 );
 
 export const resetPasswordSuccess = createAction(
@@ -134,7 +134,7 @@ export const resetPasswordSuccess = createAction(
 
 export const resetPasswordFailure = createAction(
   '[Auth/Password] Reset Password Failure',
-  props<{ error: AppError; silent?: boolean }>(),
+  props<{ error: AppError }>(),
 );
 export const updateTourStatus = createAction('[Auth/Tour] Update Tour Status');
 
@@ -145,5 +145,17 @@ export const updateTourStatusSuccess = createAction(
 
 export const updateTourStatusFailure = createAction(
   '[Auth/Tour] Update Tour Status Failure',
-  props<{ error: AppError; silent?: boolean }>(),
+  props<{ error: AppError }>(),
+);
+
+export const checkAuthSession = createAction('[Auth] Check Auth Session');
+
+export const checkAuthSessionSuccess = createAction(
+  '[Auth API] Check Auth Session Success',
+  props<{ user: User }>(),
+);
+
+export const checkAuthSessionFailure = createAction(
+  '[Auth API] Check Auth Session Failure',
+  props<{ error: AppError }>(),
 );

--- a/src/app/store/auth/auth.effects.ts
+++ b/src/app/store/auth/auth.effects.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
-import { Actions, createEffect, ofType, ROOT_EFFECTS_INIT } from '@ngrx/effects';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { Router } from '@angular/router';
-import { catchError, filter, map, switchMap, tap, withLatestFrom } from 'rxjs/operators';
+import { catchError, map, switchMap, tap, withLatestFrom } from 'rxjs/operators';
 import { of } from 'rxjs';
 
 import {
@@ -48,6 +48,9 @@ import {
   resetPassword,
   resetPasswordSuccess,
   resetPasswordFailure,
+  checkAuthSession,
+  checkAuthSessionSuccess,
+  checkAuthSessionFailure,
 } from './auth.actions';
 import { selectCurrentUser } from './auth.selectors';
 import { AppState } from '../app.state';
@@ -113,15 +116,21 @@ export class AuthEffects {
 
   public checkAuth$ = createEffect(() =>
     this.actions$.pipe(
-      ofType(ROOT_EFFECTS_INIT),
+      ofType(checkAuthSession),
       switchMap(() =>
         this.authService.getUserProfile().pipe(
-          map(({ data }) => loginSuccess({ user: mapUserApiResponseToUser(data) })),
+          map(({ data }) =>
+            checkAuthSessionSuccess({
+              user: mapUserApiResponseToUser(data),
+            }),
+          ),
           catchError((httpError: HttpErrorResponse) => {
             return of(
-              loginFailure({
-                error: { message: 'No active session', type: AppErrorType.AUTH },
-                silent: true,
+              checkAuthSessionFailure({
+                error: {
+                  message: 'No active session',
+                  type: AppErrorType.AUTH,
+                },
               }),
             );
           }),
@@ -448,12 +457,6 @@ export class AuthEffects {
     () =>
       this.actions$.pipe(
         ofType(logoutSuccess, loginFailure),
-        filter((action) => {
-          if (action.type === loginFailure.type) {
-            return !action.silent;
-          }
-          return true;
-        }),
         tap(() => {
           this.router.navigateByUrl(APP_ROUTES.LOGIN);
         }),
@@ -479,13 +482,11 @@ export class AuthEffects {
           resetPasswordFailure,
           resendVerificationFailure,
         ),
-        tap(({ error, silent }) => {
-          if (!silent) {
-            this.toastService.showError(
-              error.type?.charAt(0).toUpperCase() + error.type!.slice(1) + ' Failed',
-              error.message,
-            );
-          }
+        tap(({ error }) => {
+          this.toastService.showError(
+            error.type?.charAt(0).toUpperCase() + error.type!.slice(1) + ' Failed',
+            error.message,
+          );
         }),
       ),
     { dispatch: false },

--- a/src/app/store/auth/auth.effects.ts
+++ b/src/app/store/auth/auth.effects.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { Actions, createEffect, ofType, ROOT_EFFECTS_INIT } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { Router } from '@angular/router';
 import { catchError, map, switchMap, tap, withLatestFrom } from 'rxjs/operators';
@@ -111,6 +111,25 @@ export class AuthEffects {
     ),
   );
 
+  public checkAuth$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(ROOT_EFFECTS_INIT),
+      switchMap(() =>
+        this.authService.getUserProfile().pipe(
+          map(({ data }) => loginSuccess({ user: mapUserApiResponseToUser(data) })),
+          catchError((httpError: HttpErrorResponse) => {
+            return of(
+              loginFailure({
+                error: { message: 'No active session', type: AppErrorType.AUTH },
+                silent: true,
+              }),
+            );
+          }),
+        ),
+      ),
+    ),
+  );
+
   public login$ = createEffect(() =>
     this.actions$.pipe(
       ofType(login),
@@ -196,9 +215,9 @@ export class AuthEffects {
       this.actions$.pipe(
         ofType(loginSuccess),
         tap(({ user }) => {
-           this.toastService.showSuccess(
+          this.toastService.showSuccess(
             'Login Successful!',
-            "Login successful! Redirecting you to your dashboard...",
+            'Login successful! Redirecting you to your dashboard...',
           );
           if (user.state === UserState.ONBOARDED) {
             this.router.navigateByUrl(APP_ROUTES.DASHBOARD);
@@ -450,12 +469,16 @@ export class AuthEffects {
           logoutFailure,
           socialLoginFailure,
           updateTourStatusFailure,
+          resetPasswordFailure,
+          resendVerificationFailure,
         ),
-        tap(({ error }) => {
-          this.toastService.showError(
-            error.type?.charAt(0).toUpperCase() + error.type!.slice(1) + ' Failed',
-            error.message,
-          );
+        tap(({ error, silent }) => {
+          if (!silent) {
+            this.toastService.showError(
+              error.type?.charAt(0).toUpperCase() + error.type!.slice(1) + ' Failed',
+              error.message,
+            );
+          }
         }),
       ),
     { dispatch: false },

--- a/src/app/store/auth/auth.effects.ts
+++ b/src/app/store/auth/auth.effects.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType, ROOT_EFFECTS_INIT } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { Router } from '@angular/router';
-import { catchError, map, switchMap, tap, withLatestFrom } from 'rxjs/operators';
+import { catchError, filter, map, switchMap, tap, withLatestFrom } from 'rxjs/operators';
 import { of } from 'rxjs';
 
 import {
@@ -453,6 +453,27 @@ export class AuthEffects {
             error.type?.charAt(0).toUpperCase() + error.type!.slice(1) + ' Failed',
             error.message,
           );
+        }),
+      ),
+    { dispatch: false },
+  );
+
+  public logoutOrAuthFailure$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(logoutSuccess, loginFailure),
+        filter((action) => {
+          if (action.type === loginFailure.type) {
+            return !action.silent;
+          }
+          return true;
+        }),
+        tap(() => {
+          this.router.navigateByUrl(APP_ROUTES.LOGIN);
+        }),
+        catchError((httpError: HttpErrorResponse) => {
+          const appError = this.errorHandlerService.getError(httpError);
+          return of(loginFailure({ error: appError }));
         }),
       ),
     { dispatch: false },

--- a/src/app/store/auth/auth.effects.ts
+++ b/src/app/store/auth/auth.effects.ts
@@ -50,7 +50,6 @@ import {
   resetPasswordFailure,
   checkAuthSession,
   checkAuthSessionSuccess,
-  checkAuthSessionFailure,
 } from './auth.actions';
 import { selectCurrentUser } from './auth.selectors';
 import { AppState } from '../app.state';
@@ -125,14 +124,7 @@ export class AuthEffects {
             }),
           ),
           catchError((httpError: HttpErrorResponse) => {
-            return of(
-              checkAuthSessionFailure({
-                error: {
-                  message: 'No active session',
-                  type: AppErrorType.AUTH,
-                },
-              }),
-            );
+            return of(logout());
           }),
         ),
       ),

--- a/src/app/store/auth/auth.effects.ts
+++ b/src/app/store/auth/auth.effects.ts
@@ -330,20 +330,6 @@ export class AuthEffects {
     { dispatch: false },
   );
 
-  public loginFailure$ = createEffect(
-    () =>
-      this.actions$.pipe(
-        ofType(loginFailure),
-        tap(({ error }) => {
-          this.toastService.showError(
-            'Login Failed',
-            error?.message || 'Invalid email or password. Please try again.',
-          );
-        }),
-      ),
-    { dispatch: false },
-  );
-
   public resendVerification$ = createEffect(() =>
     this.actions$.pipe(
       ofType(resendVerification),

--- a/src/app/store/auth/auth.reducer.ts
+++ b/src/app/store/auth/auth.reducer.ts
@@ -26,6 +26,9 @@ import {
   resetPassword,
   resetPasswordSuccess,
   resetPasswordFailure,
+  checkAuthSession,
+  checkAuthSessionSuccess,
+  checkAuthSessionFailure,
 } from './auth.actions';
 
 export const authReducer = createReducer(
@@ -169,5 +172,24 @@ export const authReducer = createReducer(
     isResettingPassword: false,
     resetPasswordError: error,
     resetPasswordSuccess: false,
+  })),
+  on(checkAuthSession, (state) => ({
+    ...state,
+    isCheckingAuthSession: true,
+    checkAuthSessionError: null,
+  })),
+  on(checkAuthSessionSuccess, (state, { user }) => ({
+    ...state,
+    isCheckingAuthSession: false,
+    isAuthenticated: true,
+    user: user,
+    checkAuthSessionError: null,
+  })),
+  on(checkAuthSessionFailure, (state, { error }) => ({
+    ...state,
+    isCheckingAuthSession: false,
+    isAuthenticated: false,
+    user: null,
+    checkAuthSessionError: error,
   })),
 );

--- a/src/app/store/auth/auth.state.ts
+++ b/src/app/store/auth/auth.state.ts
@@ -24,6 +24,8 @@ export interface AuthState {
   isResettingPassword: boolean;
   resetPasswordError: AppError | null;
   resetPasswordSuccess: boolean;
+  isCheckingAuthSession: boolean;
+  checkAuthSessionError: AppError | null;
 }
 
 export const initialAuthState: AuthState = {
@@ -49,4 +51,6 @@ export const initialAuthState: AuthState = {
   isResettingPassword: false,
   resetPasswordError: null,
   resetPasswordSuccess: false,
+  isCheckingAuthSession: false,
+  checkAuthSessionError: null,
 };


### PR DESCRIPTION
**Related Ticket:** Closes [[GSDT 411](https://amali-tech.atlassian.net/browse/GSDT-411)]

**Description**

This PR fixes the critical bug where a hard page refresh would wipe the NgRx state (isAuthenticated: false) and incorrectly kick a user with a valid session cookie back to the login page.

It implements the **"Re-Fetch on Load" pattern** to securely re-hydrate the NgRx state from the server on every application load, using the `HttpOnly` cookie as the "key."

**Security Context**

This approach intentionally avoids localStorage persistence (like ngrx-store-localstorage). Storing the User object or auth flags in localStorage would create an XSS vulnerability and completely defeat the security purpose of our HttpOnly cookie strategy. This PR maintains that secure architecture.

**Changes Made**

-   Adds `getUserProfile()` to the `AuthService` (which calls `GET /api/v1/users/profile/me`).

-   Creates a new `checkAuth$` effect in `AuthEffects` that listens for `ROOT_EFFECTS_INIT` (the app load event).

-   On app load, this effect now calls `getSelfProfile()`.

-   **On Success (valid cookie):** It dispatches `loginSuccess` to re-hydrate the store.

-   **On Failure (no cookie):** It dispatches `loginFailure({ silent: true })` to prevent the "toast-on-load" bug for new users.

### **How to Test**

This must be tested in two scenarios:

**1\. As a Logged-In User:**

-   [ ] Log in to the application.

-   [ ] Go to the `/dashboard` page.

-   [ ] Perform a **hard refresh** (Cmd+Shift+R or Ctrl+F5).

-   [ ] **Expected:** The page reloads. You should see the `loginSuccess` action fire in Redux DevTools, and you must **remain on the dashboard** (not be kicked to `/login`).

**2\. As a New / Logged-Out User:**

-   [ ] Log out completely (or use an incognito window).

-   [ ] Load the landing page or `/login` page.

-   [ ] **Expected:** The page loads normally. You should see the `loginFailure({ silent: true })` action in Redux DevTools, and **no "Login Failed" toast should appear.**