### PR TITLE
style(GSDT 508): add base skeleton styles

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -41,6 +41,7 @@
   --color-background-overlay: #{$background-overlay};
   --color-white: #{$white};
   --color-text-gray: #{$text-gray};
+  --color-gray-background-weak: #{$gray-background-weak};
 
   --space-xs: #{$space-xs};
   --space-sm: #{$space-sm};

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -39,6 +39,7 @@ $gray-stroke-weak: #e7e7e7;
 $gray-light: #d9d9d9;
 $gray-fill: #f6f6f6;
 $gray-white: #ffffff;
+$gray-background-weak: #e5e7eb;
 
 /* Orange */
 $orange-text: #f2994a;

--- a/src/styles/_skeletons.scss
+++ b/src/styles/_skeletons.scss
@@ -1,0 +1,21 @@
+@keyframes shimmer {
+  0% {
+    background-position: -468px 0;
+  }
+  100% {
+    background-position: 468px 0;
+  }
+}
+
+.skeleton-placeholder {
+  animation: shimmer 1.5s infinite linear;
+  background-color: var(--color-gray-background-weak);
+  background-image: linear-gradient(
+    to right,
+    var(--color-gray-background-weak) 8%,
+    var(--color-gray-fill) 18%,
+    var(--color-gray-background-weak) 33%
+  );
+  background-size: 800px 104px;
+  border-radius: 6px;
+}


### PR DESCRIPTION
This PR introduces a shared, reusable system for skeleton loading animations across the application.

Instead of duplicating the "shimmer" animation and placeholder styles in every component's SCSS file, we now have a centralized `_skeletons.scss` partial. This ensures consistent loading UI and makes it trivial to add new skeletons in the future.

### Changes Made

**1\. Created `_skeletons.scss`**

-   Defined the `@keyframes shimmer` animation.

-   Created a `.skeleton-placeholder` class that can be `@extend`-ed by any component.

-   Sets consistent background gradients and border-radius defaults.

**2\. Refactored `StatsSkeletonComponent`**

-   Updated `stats-skeleton.component.scss` to `@use` the new global file.

-   Removed the duplicate animation code.

-   Applied the new styles to ensure the skeleton cards match the "mobile-first" horizontal scrolling layout of the real stats cards.

### How to Use (for other devs)

In any component's SCSS file:

```
@use 'styles/skeletons' as *;

.my-loading-box {
  @extend .skeleton-placeholder;
  width: 100px;
  height: 20px;
}

```

### How to Test

1.  Go to the Dashboard.

2.  Observe the loading state (refresh if needed).

3.  **Desktop:** Verify the 3 skeleton cards appear in a grid and have the shimmering animation.

4.  **Mobile:** Verify the skeleton cards are in a horizontal scrolling row, matching the layout of the real cards.