### PR TITLE
fix(GSDT 515): fix go back navigation bug on email verification page

### DIFF
--- a/src/app/core/guards/guest-guard.ts
+++ b/src/app/core/guards/guest-guard.ts
@@ -14,7 +14,7 @@ export const guestGuard: CanActivateFn = () => {
   const user = store.selectSignal(AuthSelectors.selectCurrentUser)();
   const isAuthenticated = store.selectSignal(AuthSelectors.selectIsAuthenticated)();
 
-  if (!isAuthenticated || !user) {
+  if (!isAuthenticated || !user || !user.isVerified) {
     return true;
   }
 


### PR DESCRIPTION
### **Overview**

This PR resolves an issue where authenticated users on the **Email Verification** page were unable to navigate back to the **Sign Up** page due to the behavior of the `guestGuard`. The guard was previously preventing navigation for users who were recognized as authenticated, even if they were *not yet verified*. As a result, clicking **Go Back** redirected them incorrectly back to the Email Verification page.

### **What Was Causing the Bug**

-   The original guard logic only allowed non-authenticated users or users with no user object.

-   Verified and authenticated states were not differentiated properly.

-   Users in the **"authenticated but not verified"** state were blocked from visiting signup, triggering a redirect loop.

### **Fix Implemented**

Updated `guestGuard` logic to correctly allow **authenticated but unverified** users to access routes guarded by `guestGuard`, such as the **Sign Up** page after clicking Go Back:

`if (!isAuthenticated || !user || !user.isVerified) {
  return true;
}`

This ensures:

-   Unauthenticated users → allowed

-   Users with no user object → allowed

-   Authenticated but **NOT verified** users → allowed

-   Verified or onboarded users → properly redirected to their respective pages

### **Result**

-   Clicking **Go Back** on the Email Verification page now works as expected.

-   Navigation is consistent with the application's authentication flow.

-   No more redirect loop between Sign Up and Email Verification.

### **Additional Notes**

-   No UI changes were required.

-   Behavior across all authentication-related routes remains stable.