### PR TITLE
fix(GSDT 521): add sidebar active state for task item during assessment

### DIFF
--- a/src/app/shared/components/dashboard-sidebar/dashboard-sidebar.html
+++ b/src/app/shared/components/dashboard-sidebar/dashboard-sidebar.html
@@ -15,7 +15,7 @@
             [routerLink]="item.route"
             (click)="onNavigate()"
             routerLinkActive="active"
-            [routerLinkActiveOptions]="{ exact: true }"
+            [routerLinkActiveOptions]="getRouterLinkOptions(item.route)"
             [attr.data-tour-id]="item.tourId"
           >
             <lucide-icon [name]="item.icon" [size]="20" color="currentColor" [strokeWidth]="1.5" />

--- a/src/app/shared/components/dashboard-sidebar/dashboard-sidebar.ts
+++ b/src/app/shared/components/dashboard-sidebar/dashboard-sidebar.ts
@@ -41,4 +41,8 @@ export class DashboardSidebar {
     if (this.isSubmitting()) return;
     this.store.dispatch(logout());
   }
+
+  public getRouterLinkOptions(route: string): { exact: boolean } {
+    return { exact: route !== '/dashboard/tasks' };
+  }
 }


### PR DESCRIPTION
Currently, when a user starts a task from the dashboard sidebar, the corresponding sidebar item does not appear active, making it unclear which task is currently selected.

This PR fixes the issue by:

-   Adding a helper method `getRouterLinkOptions(route: string)` in the component to correctly configure `[routerLinkActiveOptions]`.

-   Ensuring the dashboard sidebar highlights the active task, providing proper visual feedback to the user.

**Impact:**

-   Improves navigation clarity in the dashboard.

-   No functional changes to task selection or routing.

<img width="771" height="665" alt="Screenshot 2025-11-19 115716" src="https://github.com/user-attachments/assets/f9dbbd44-a28c-4dd7-929f-83862b50851e" />
