### PR TITLE
fix(GSDT 523) fix guided tour not showing

### DIFF
--- a/src/app/core/models/auth.model.ts
+++ b/src/app/core/models/auth.model.ts
@@ -44,6 +44,7 @@ export enum UserState {
 }
 
 export enum TourGuide {
+  NOT_STARTED = 'NOT_STARTED',
   IN_PROGRESS = 'IN_PROGRESS',
   COMPLETED = 'COMPLETED',
 }

--- a/src/app/core/services/api/api-service.ts
+++ b/src/app/core/services/api/api-service.ts
@@ -40,6 +40,14 @@ export class ApiService {
     return this.requestWithBody('put', url, body, options);
   }
 
+  public patch<Res, Req = unknown>(
+    url: string,
+    body: Req,
+    options: ApiRequestOptions = {},
+  ): Observable<Res> {
+    return this.requestWithBody('patch', url, body, options);
+  }
+
   public delete(url: string, options: ApiRequestOptions = {}): Observable<void> {
     return this.http.delete<void>(this.buildApiUrl(url), this.mergeOptions(options));
   }

--- a/src/app/core/services/auth/auth-service.ts
+++ b/src/app/core/services/auth/auth-service.ts
@@ -10,6 +10,7 @@ import {
   CompleteOnboardingRequest,
   UserEmailRequest,
   ResetPasswordRequest,
+  TourGuide,
 } from '../../models/auth.model';
 import { APP_CONSTANTS } from '../../constants/app.constants';
 import { environment } from '../../../../environments/environment';
@@ -67,9 +68,8 @@ export class AuthService {
     window.location.href = `${this.baseUrl}${API_ENDPOINTS.SOCIAL_LOGIN}/${provider}`;
   }
 
-  public updateTourStatus({ email }: UserEmailRequest): Observable<UserResponse> {
-    const params = new HttpParams().set('email', email);
-    return this.api.post<UserResponse>(API_ENDPOINTS.UPDATE_TOUR_STATUS, null, { params });
+  public updateTourStatus(tourStatus: TourGuide): Observable<UserResponse> {
+    return this.api.patch<UserResponse>(API_ENDPOINTS.UPDATE_TOUR_STATUS, { tourStatus });
   }
 
   public getUserProfile(): Observable<UserResponse> {

--- a/src/app/features/dashboard/dashboard.config.ts
+++ b/src/app/features/dashboard/dashboard.config.ts
@@ -3,6 +3,7 @@ import { ShepherdService } from 'angular-shepherd';
 import { Store } from '@ngrx/store';
 import { AppState } from '@app/store/app.state';
 import { updateTourStatus } from '@app/store/auth/auth.actions';
+import { TourGuide } from '@app/core';
 
 export const STEPS_BUTTONS = {
   back: {
@@ -47,7 +48,7 @@ export function getSteps(router: Router, service: ShepherdService, store: Store<
         {
           text: 'Skip Tour',
           action: () => {
-            store.dispatch(updateTourStatus());
+            store.dispatch(updateTourStatus({ tourStatus: TourGuide.COMPLETED }));
             service.cancel();
           },
           classes: 'shepherd-button-secondary',
@@ -106,7 +107,7 @@ export function getSteps(router: Router, service: ShepherdService, store: Store<
       },
       buttons: [STEPS_BUTTONS.cancel, STEPS_BUTTONS.finish],
       action: () => {
-        store.dispatch(updateTourStatus());
+        store.dispatch(updateTourStatus({ tourStatus: TourGuide.COMPLETED }));
       },
       id: 'skill-arena-link',
       title: 'Community',

--- a/src/app/features/dashboard/dashboard.ts
+++ b/src/app/features/dashboard/dashboard.ts
@@ -89,7 +89,7 @@ export class Dashboard implements OnInit, AfterViewInit {
   }
 
   ngAfterViewInit() {
-    if (!this.shepherdService.isActive && this.user()?.tourStatus === TourGuide.IN_PROGRESS) {
+    if (!this.shepherdService.isActive && this.user()?.tourStatus === TourGuide.NOT_STARTED) {
       this.startTour();
     }
   }

--- a/src/app/store/auth/auth.actions.ts
+++ b/src/app/store/auth/auth.actions.ts
@@ -8,6 +8,7 @@ import {
   LoginRequest,
   ResetPasswordRequest,
   CompleteOnboardingRequest,
+  TourGuide,
 } from '@app/core';
 
 export const registerUser = createAction(
@@ -136,7 +137,10 @@ export const resetPasswordFailure = createAction(
   '[Auth/Password] Reset Password Failure',
   props<{ error: AppError }>(),
 );
-export const updateTourStatus = createAction('[Auth/Tour] Update Tour Status');
+export const updateTourStatus = createAction(
+  '[Auth/Tour] Update Tour Status',
+  props<{ tourStatus: TourGuide }>(),
+);
 
 export const updateTourStatusSuccess = createAction(
   '[Auth/Tour] Update Tour Status Success',

--- a/src/app/store/auth/auth.effects.ts
+++ b/src/app/store/auth/auth.effects.ts
@@ -13,7 +13,6 @@ import {
   ToastService,
   mapUserApiResponseToUser,
   AppErrorType,
-  UserEmailRequest,
   User,
 } from '@app/core';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -173,7 +172,7 @@ export class AuthEffects {
     this.actions$.pipe(
       ofType(updateTourStatus),
       withLatestFrom(this.store.select(selectCurrentUser)),
-      switchMap(([_, user]) => {
+      switchMap(([{ tourStatus }, user]) => {
         if (!user) {
           return of(
             updateTourStatusFailure({
@@ -185,9 +184,7 @@ export class AuthEffects {
           );
         }
 
-        const request: UserEmailRequest = { email: user.email };
-
-        return this.authService.updateTourStatus(request).pipe(
+        return this.authService.updateTourStatus(tourStatus).pipe(
           map(({ data }) => {
             const updatedUser: User = {
               ...user,


### PR DESCRIPTION
**Description** This PR updates the Guided Tour functionality to align with the latest backend API contract. The endpoint for updating a user's tour status has changed to require a `PATCH` request.

To support this, I have extended the base `ApiService` to handle `PATCH` requests and updated the `AuthService` and NgRx flow to trigger the status update correctly when a user completes or skips the tour.

**Changes Made**

-   **`feat(api-service): add patch method to api service`**

    -   Extended the generic `BaseHttpService` (and `ApiService`) to include a `patch<T>()` method, allowing HTTP PATCH requests across the application.

-   **`feat: update auth service...`**

    -   Updated the `updateTourStatus` method in `AuthService` to use the new `patch` method and target the correct API endpoint.

-   **`fix: trigger tour status update`**

    -   Connected the NgRx effects for the Guided Tour (Skip/Finish actions) to the `AuthService`.

    -   Ensures the backend is notified immediately when a user dismisses the tour so it doesn't show up again.

### **How to Test**

1.  Pull this branch and run the app.

2.  **Trigger the Tour:** (If the `isGuided` flag isn't ready, use the manual trigger or a temporary button).

3.  **Interaction:** Click "Skip" or go through the steps and click "Finish".

4.  **Verify Network Request:**

    -   [ ] Open the Browser DevTools **Network Tab**.

    -   [ ] Confirm that a request is sent to the tour status endpoint.

    -   [ ] **Critical:** Confirm the request method is **`PATCH`** (not POST or PUT).

    -   [ ] Confirm the response is 200 OK.

5.  **Verify State:**

    -   [ ] Check Redux DevTools to see the tour completion action dispatched successfully.