### PR TITLE
style(GSDT 525): make flex wrap to the next line

### DIFF
--- a/src/app/features/interests-selection/interests-selection.scss
+++ b/src/app/features/interests-selection/interests-selection.scss
@@ -38,6 +38,7 @@
   &-selection {
     margin-top: 48px;
     @include flex($direction: row, $align: center);
+    flex-wrap: wrap;
   }
 
   &-btns {


### PR DESCRIPTION
This PR fixes a style issue on the interest selection screen by adding a `flex-wrap: wrap` 

<img width="1005" height="724" alt="Screenshot 2025-11-20 at 10 11 04 AM" src="https://github.com/user-attachments/assets/4291f1a1-3233-49aa-9540-b029d6ad049c" />
