### PR TITLE
fix(GSDT 531): ensure tour finish button updates backend status

### DIFF
--- a/src/app/features/dashboard/dashboard.config.ts
+++ b/src/app/features/dashboard/dashboard.config.ts
@@ -15,7 +15,7 @@ export const STEPS_BUTTONS = {
   cancel: {
     classes: 'cancel-button',
     secondary: true,
-    text: 'Skip Tour',
+    text: 'Cancel',
     type: 'cancel',
   },
   next: {
@@ -105,10 +105,17 @@ export function getSteps(router: Router, service: ShepherdService, store: Store<
         element: '[data-tour-id="sidebar-groups"]',
         on: 'right',
       },
-      buttons: [STEPS_BUTTONS.cancel, STEPS_BUTTONS.finish],
-      action: () => {
-        store.dispatch(updateTourStatus({ tourStatus: TourGuide.COMPLETED }));
-      },
+      buttons: [
+        STEPS_BUTTONS.cancel,
+        {
+          text: 'Finish Tour',
+          action: () => {
+            store.dispatch(updateTourStatus({ tourStatus: TourGuide.COMPLETED }));
+            service.complete();
+          },
+          classes: 'shepherd-button-primary',
+        },
+      ],
       id: 'skill-arena-link',
       title: 'Community',
       text: 'Join or create groups to learn together. Collaborate, share progress, and support each other on your skill journey.',


### PR DESCRIPTION
**Related Ticket:** Closes [[GSDT 531](https://amali-tech.atlassian.net/browse/GSDT-531)]

**Description** This PR fixes a bug where completing the Guided Tour (clicking the **"Finish"** button) would close the modal UI but fail to send the status update to the backend. This caused the tour to incorrectly reappear on the next page load.

**Root Cause** The specific event handler for the "Finish" button was missing the call to dispatch the `updateTourStatus` action. It was only configured to `tour.complete()` (which just closes the UI).

**Changes Made**

-   **`fix(onboarding): trigger api call on tour finish`**

    -   Updated the `TourService` configuration for the final step.

    -   Added a callback to the "Finish" button/complete event to explicitly dispatch the NgRx action (or call the `AuthService`) that triggers the `PATCH` API request.

**How to Test**

1.  Pull this branch and run the app.

2.  **Trigger the Tour:** (Use the manual trigger or temporary button if `isGuided` isn't live yet).

3.  **Complete the Tour:** Click through the steps until you reach the final modal.

4.  **Click "Finish":**

    -   [ ] **Network Check:** Open the DevTools Network tab and confirm a **`PATCH`** request is sent to the backend (200 OK).

    -   [ ] **UI Check:** Confirm the tour modal closes.

5.  **Verify Persistence:**

    -   [ ] Refresh the page.

    -   [ ] **Expected:** The tour should **not** start again automatically (assuming the backend correctly saved the `true` status).