### PR TITLE
fix(GSDT 532): suppress global error toast for locally handled requests

### DIFF
--- a/src/app/core/constants/app.constants.ts
+++ b/src/app/core/constants/app.constants.ts
@@ -1,3 +1,5 @@
+import { HttpContextToken } from '@angular/common/http';
+
 export const APP_CONSTANTS = {
   RETRY: {
     COUNT: 2,
@@ -46,3 +48,5 @@ export const APP_CONSTANTS = {
     },
   },
 } as const;
+
+export const SKIP_ERROR_NOTIFICATION = new HttpContextToken<boolean>(() => false);

--- a/src/app/core/interceptors/global-http-error-interceptor.ts
+++ b/src/app/core/interceptors/global-http-error-interceptor.ts
@@ -5,6 +5,7 @@ import { catchError, throwError } from 'rxjs';
 import { AuthService } from '../services/auth/auth-service';
 import { ToastService } from '../services/toast/toast-service';
 import { ErrorHandlerService } from '../services/error/error-handler';
+import { SKIP_ERROR_NOTIFICATION } from '../constants/app.constants';
 
 export const globalHttpErrorInterceptor: HttpInterceptorFn = (req, next) => {
   const authService = inject(AuthService);
@@ -13,6 +14,8 @@ export const globalHttpErrorInterceptor: HttpInterceptorFn = (req, next) => {
 
   return next(req).pipe(
     catchError((error: HttpErrorResponse) => {
+      const shouldSkipToast = req.context.get(SKIP_ERROR_NOTIFICATION);
+
       if (error.status === 401) {
         authService.logout();
       }
@@ -20,12 +23,12 @@ export const globalHttpErrorInterceptor: HttpInterceptorFn = (req, next) => {
       const isNetworkError = error.status === 0;
       const isServerError = error.status >= 500 && error.status < 600;
 
-      if (isNetworkError || isServerError) {
+      if (!shouldSkipToast && (isNetworkError || isServerError)) {
         const appError = errorHandlerService.getError(error);
 
         toastService.showError('Error', appError.message);
       }
-      
+
       return throwError(() => error);
     }),
   );

--- a/src/app/core/models/api.model.ts
+++ b/src/app/core/models/api.model.ts
@@ -1,8 +1,9 @@
-import { HttpParams, HttpHeaders } from '@angular/common/http';
+import { HttpParams, HttpHeaders, HttpContext } from '@angular/common/http';
 
 export interface ApiRequestOptions {
   params?: HttpParams | Record<string, string | number | boolean>;
   headers?: HttpHeaders | Record<string, string | string[]>;
+  context?: HttpContext;
 }
 
 export interface ValidationDetail {

--- a/src/app/core/services/dashboard/dashboard-service.spec.ts
+++ b/src/app/core/services/dashboard/dashboard-service.spec.ts
@@ -5,6 +5,7 @@ import { DashboardService } from './dashboard.service';
 import { ApiService } from '../../services/api/api-service';
 import { APP_CONSTANTS } from '../../constants/app.constants';
 import { TrajectoryGranularity } from '../../models/dashboard.model';
+import { HttpContext } from '@angular/common/http';
 
 const mockApiService = {
   get: jest.fn(),
@@ -52,7 +53,13 @@ describe('DashboardService', () => {
 
       service.getDashboardRecommendedTasks().subscribe((response) => {
         expect(response).toEqual(mockResponse);
-        expect(apiService.get).toHaveBeenCalledWith(API_ENDPOINTS.DASHBOARD_RECOMMENDED_TASKS);
+
+        expect(apiService.get).toHaveBeenCalledWith(
+          API_ENDPOINTS.DASHBOARD_RECOMMENDED_TASKS,
+          expect.objectContaining({
+            context: expect.any(HttpContext),
+          }),
+        );
         done();
       });
     });

--- a/src/app/core/services/dashboard/dashboard.service.ts
+++ b/src/app/core/services/dashboard/dashboard.service.ts
@@ -7,8 +7,9 @@ import {
   TrajectoryGranularity,
   SkillTrajectoryResponse,
 } from '../../models/dashboard.model';
-import { APP_CONSTANTS } from '../../constants/app.constants';
+import { APP_CONSTANTS, SKIP_ERROR_NOTIFICATION } from '../../constants/app.constants';
 import { ApiService } from '../../services/api/api-service';
+import { HttpContext } from '@angular/common/http';
 
 const { API_ENDPOINTS } = APP_CONSTANTS;
 
@@ -23,7 +24,9 @@ export class DashboardService {
   }
 
   public getDashboardRecommendedTasks(): Observable<RecommendedTasksResponse> {
-    return this.api.get<RecommendedTasksResponse>(API_ENDPOINTS.DASHBOARD_RECOMMENDED_TASKS);
+    return this.api.get<RecommendedTasksResponse>(API_ENDPOINTS.DASHBOARD_RECOMMENDED_TASKS, {
+      context: new HttpContext().set(SKIP_ERROR_NOTIFICATION, true),
+    });
   }
 
   public getDashboardTrajectory(


### PR DESCRIPTION
**Related Ticket:** Closes [[GSDT 532](https://amali-tech.atlassian.net/browse/GSDT-532)]

**Description** This PR introduces a mechanism to suppress the global error toast notification for specific HTTP requests.

**Problem:** Currently, the `GlobalHttpErrorInterceptor` triggers a red error toast for *all* errors. This causes a confusing UX in scenarios where a component explicitly handles a 404 error (e.g., by showing an "Empty State" or "Not Found" UI), resulting in a redundant error popup.

**Solution:** I have implemented an `HttpContext` token that allows specific service calls to opt-out of the global error handling.

**Changes Made**

1.  **Context Token:** Created `SKIP_ERROR_NOTIFICATION` token in `http-context.tokens.ts`.

2.  **Interceptor:** Updated `GlobalHttpErrorInterceptor` to check for this token. If present, it skips the `ToastService.showError()` call.

3.  **Base Service:** Updated `ApiRequestOptions` interface and `BaseHttpService` (or `ApiService`) to accept and pass the `HttpContext` down to the Angular `HttpClient`.

4.  **Implementation:** Updated the `DashboardService` (specifically the recommended tasks call) to use this token, ensuring the "No Tasks Found" state doesn't trigger a global error.

### **How to Test**

**1\. Verify Suppression (The Fix):**

-   Temporarily break the endpoint URL in `DashboardService` (e.g., add `_BROKEN` to the URL) for the request using the new context.

-   Run the app and load the dashboard.

-   **Expected:** You should see the component's local error/empty state, but **NO** global red error toast should appear.

**2\. Verify Regression (Normal Behavior):**

-   Temporarily break a *different* endpoint (one that does *not* use the token, like the User Profile or Stats).

-   Reload the page.

-   **Expected:** You **SHOULD** see the global red error toast as usual.