### PR TITLE
fix(GSDT 533): ensure retry button triggers data reload

### DIFF
--- a/src/app/features/dashboard/components/dashboard-recommended-tasks/dashboard-recommended-tasks.html
+++ b/src/app/features/dashboard/components/dashboard-recommended-tasks/dashboard-recommended-tasks.html
@@ -6,10 +6,11 @@
   <div class="tasks-list">
     @if (isRecommendedTasksLoading) {
       <app-recommended-tasks-card-skeleton />
-    } @else if (recommendedTasksError; as err) {
+    } @else if (recommendedTasksError; as error) {
       <app-dashboard-error-component
         [title]="'Could not load Recommended Tasks'"
-        [message]="err.message"
+        [message]="error.message"
+        (retry)="handleRetryClick()"
       />
     } @else {
       @for (task of recommendations; track task.id) {

--- a/src/app/features/dashboard/components/dashboard-recommended-tasks/dashboard-recommended-tasks.ts
+++ b/src/app/features/dashboard/components/dashboard-recommended-tasks/dashboard-recommended-tasks.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { AppError, RecommendedTaskUI } from '@app/core';
 import { CustomDropdown } from '@app/shared/components/custom-dropdown/custom-dropdown';
 import { DashboardErrorComponent } from '../dashboard-error-component/dashboard-error-component';
@@ -21,4 +21,9 @@ export class DashboardRecommendedTasks {
   @Input({ required: true }) public recommendations: RecommendedTaskUI[] = [];
   @Input() public isRecommendedTasksLoading = false;
   @Input() public recommendedTasksError: AppError | null = null;
+  @Output() public retry = new EventEmitter<void>();
+
+  public handleRetryClick() {
+    this.retry.emit();
+  }
 }

--- a/src/app/features/dashboard/dashboard.html
+++ b/src/app/features/dashboard/dashboard.html
@@ -20,6 +20,7 @@
       [recommendations]="recommendedTasks()"
       [isRecommendedTasksLoading]="isRecommendedTasksLoading()"
       [recommendedTasksError]="selectRecommendedTasksError()"
+      (retry)="getRecommendedTasks()"
     />
     <app-dashboard-progress-overview-component
       [primarySkillProgress]="primarySkillProgress()"


### PR DESCRIPTION
**Related Ticket:** Closes [[GSDT 533](https://amali-tech.atlassian.net/browse/GSDT-533)]

**Description** This PR fixes a bug where the **"Retry"** button on the Dashboard Error state was unresponsive. Clicking it did not trigger a data reload, leaving the user stuck on the error screen.

**Root Cause** The `DashboardErrorComponent` was properly displaying the UI, but the click event from the button was not correctly emitting an `@Output` event, or the parent component was not listening to it to trigger the NgRx action.

**Changes Made**

-   **`dashboard-error.component.ts`**:

    -   Added/Verified the `@Output() retry = new EventEmitter<void>();` emitter.

    -   Connected the button click to emit this event.

-   **`dashboard.component.html`**:

    -   Added the event binding `(retry)="onRetry()"` to the `<app-dashboard-error>` tag.

-   **`dashboard.component.ts`**:

    -   Implemented the `onRetry()` method to dispatch the `[Dashboard] Load Dashboard` action.

**How to Test**

1.  Pull this branch and run the app.

2.  **Force an Error:**

    -   Temporarily disconnect your internet OR block the network request in DevTools (Network request blocking) to force the dashboard API to fail.

3.  **Verify Error State:**

    -   Confirm the "Error" component appears.

4.  **Test Retry:**

    -   Re-enable your internet (or unblock the request).

    -   Click the **"Retry"** button.

    -   [ ] **Expected:** The UI should immediately switch back to the **Skeleton/Loading** state.

    -   [ ] **Expected:** A new network request should fire.

    -   [ ] **Expected:** The dashboard should load successfully.