### PR TITLE
feat(GSDT 535): connect progress overview to live data

### DIFF
--- a/src/app/features/dashboard/components/dashboard-progress-overview-component/dashboard-progress-overview-component.html
+++ b/src/app/features/dashboard/components/dashboard-progress-overview-component/dashboard-progress-overview-component.html
@@ -10,21 +10,32 @@
       <div class="filters">
         <div class="skill-filter">
           <p>Skill:</p>
-          <app-custom-dropdown [options]="['HTML', 'CSS', 'JavaScript']" selectedValue="HTML" />
+          <p>Selected: {{ selectedSkill }}</p>
+          <p>Skills count: {{ userSkills.length }}</p>
+
+          <select
+            class="styled-select"
+            [ngModel]="selectedSkill"
+            (ngModelChange)="onSelectSkill($event)"
+          >
+            @for (skill of userSkills; track skill.skillId) {
+              <option [ngValue]="skill.skillId">{{ skill.skillName }}</option>
+            }
+          </select>
         </div>
 
         <div class="period-filter">
           <p>View:</p>
 
           <div class="button-group" role="group">
-            <button [class.active]="selectedPeriod === 'daily'" (click)="onSelectPeriod('daily')">
+            <button [class.active]="selectedPeriod === 'DAILY'" (click)="onSelectPeriod('daily')">
               Daily
             </button>
-            <button [class.active]="selectedPeriod === 'weekly'" (click)="onSelectPeriod('weekly')">
+            <button [class.active]="selectedPeriod === 'WEEKLY'" (click)="onSelectPeriod('weekly')">
               Weekly
             </button>
             <button
-              [class.active]="selectedPeriod === 'monthly'"
+              [class.active]="selectedPeriod === 'MONTHLY'"
               (click)="onSelectPeriod('monthly')"
             >
               Monthly

--- a/src/app/features/dashboard/components/dashboard-progress-overview-component/dashboard-progress-overview-component.scss
+++ b/src/app/features/dashboard/components/dashboard-progress-overview-component/dashboard-progress-overview-component.scss
@@ -1,5 +1,7 @@
 @use 'typography' as *;
 @use 'mixins' as *;
+@use 'colors' as *;
+@use 'typography' as *;
 
 :host {
   display: block;
@@ -80,6 +82,42 @@ $error-btn-border: #b91c1c;
     font-size: 12px;
     padding: 6px 8px;
     margin: 0 auto;
+  }
+}
+
+.styled-select {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+
+  display: inline-block;
+  width: 100%;
+  min-width: 5rem;
+
+  @include h14;
+  color: $gray-text-strong;
+  background-color: $white;
+
+  border: 1px solid $text-gray;
+  border-radius: 0.375rem;
+
+  padding: 0.375rem 2.5rem 0.375rem 0.625rem;
+
+  background-image: url('/assets/caret-down.png');
+  background-repeat: no-repeat;
+  background-position: right 0.5rem center;
+  background-size: 1.25rem;
+
+  cursor: pointer;
+
+  &:focus {
+    outline: 2px solid $text-gray;
+    outline-offset: 2px;
+  }
+
+  @include mobile-large {
+    @include h13;
+    min-width: 6.938rem;
   }
 }
 

--- a/src/app/features/dashboard/components/dashboard-progress-overview-component/dashboard-progress-overview-component.ts
+++ b/src/app/features/dashboard/components/dashboard-progress-overview-component/dashboard-progress-overview-component.ts
@@ -1,14 +1,22 @@
 import { Component, ChangeDetectionStrategy, Input, Output, EventEmitter } from '@angular/core';
 import { ProgressBar, ProgressChart } from '@app/shared';
 import { CustomDropdown } from '@app/shared/components/custom-dropdown/custom-dropdown';
-import { AppError, SkillProgress } from '@app/core';
+import { AppError, SkillProgress, UserSelectedSkill } from '@app/core';
 import { CapitalizePipe } from '@app/shared/pipes/capitalize.pipe';
 import { ProgressBarSkeleton } from '../progress-bar-skeleton/progress-bar-skeleton';
+import { FormsModule } from '@angular/forms';
 
 @Component({
   standalone: true,
   selector: 'app-dashboard-progress-overview-component',
-  imports: [ProgressBar, ProgressChart, CustomDropdown, CapitalizePipe, ProgressBarSkeleton],
+  imports: [
+    ProgressBar,
+    ProgressChart,
+    CustomDropdown,
+    CapitalizePipe,
+    ProgressBarSkeleton,
+    FormsModule,
+  ],
   templateUrl: './dashboard-progress-overview-component.html',
   styleUrl: './dashboard-progress-overview-component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -18,25 +26,31 @@ export class DashboardProgressOverviewComponent {
   @Input({ required: true }) public progressChartData: { label: string; value: number }[] = [];
   @Input({ required: true }) public isDashboardAnalyticsLoading: boolean = false;
   @Input({ required: true }) public isDashboardAnalyticsError: AppError | null = null;
+  @Input() public isUserSkillsLoading: boolean = false;
 
   @Input({ required: true }) public selectedPeriod: string = 'weekly';
   @Output() public selectPeriod = new EventEmitter<string>();
+  @Output() public selectSkill = new EventEmitter<string>();
+  @Input() public selectedSkill: string | null = null;
+  @Input() public userSkills: UserSelectedSkill[] = [];
 
-  public data = {
-    progressChartData: {
-      weekly: [
-        { label: 'Mon', value: 30 },
-        { label: 'Tue', value: 10 },
-        { label: 'Wed', value: 5 },
-        { label: 'Thu', value: 0 },
-        { label: 'Fri', value: 0 },
-        { label: 'Sat', value: 0 },
-        { label: 'Sun', value: 0 },
-      ],
-    },
-  } as const;
+  public get skillOptions(): string[] {
+    return this.userSkills.map((skill) => skill.skillName);
+  }
+
+  public get selectedSkillName(): string {
+    const skill = this.userSkills.find((skill) => skill.skillId === this.selectedSkill);
+    return skill?.skillName || '';
+  }
 
   public onSelectPeriod(period: string): void {
     this.selectPeriod.emit(period);
+  }
+
+  public onSelectSkill(skillId: string): void {
+    const skill = this.userSkills.find((skill) => skill.skillId === skillId);
+    if (skill) {
+      this.selectSkill.emit(skill.skillId);
+    }
   }
 }

--- a/src/app/features/dashboard/dashboard.html
+++ b/src/app/features/dashboard/dashboard.html
@@ -23,11 +23,14 @@
     />
     <app-dashboard-progress-overview-component
       [primarySkillProgress]="primarySkillProgress()"
-      [progressChartData]="data.progressChartData.weekly"
+      [progressChartData]="progressChartData()"
       [selectedPeriod]="selectedPeriod()"
       [isDashboardAnalyticsError]="isDashboardAnalyticsError()"
       [isDashboardAnalyticsLoading]="isDashboardAnalyticsLoading()"
-      (selectPeriod)="selectPeriod($event)"
+      (selectPeriod)="onPeriodChange($event)"
+      [selectedSkill]="selectedSkillId()"
+      (selectSkill)="onSkillChange($event)"
+      [userSkills]="userSkills()"
     />
   </main>
 </div>

--- a/src/app/features/dashboard/dashboard.ts
+++ b/src/app/features/dashboard/dashboard.ts
@@ -1,4 +1,11 @@
-import { ChangeDetectionStrategy, Component, AfterViewInit, signal, OnInit } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  AfterViewInit,
+  signal,
+  OnInit,
+  computed,
+} from '@angular/core';
 import { Router } from '@angular/router';
 import { StepOptions } from 'shepherd.js';
 import { ShepherdService } from 'angular-shepherd';
@@ -6,11 +13,15 @@ import { Store } from '@ngrx/store';
 import { LucideAngularModule } from 'lucide-angular';
 
 import { getSteps as defaultSteps, defaultStepOptions } from './dashboard.config';
+import { TrajectoryGranularity } from '@app/core';
 
 import { AppState } from '@app/store/app.state';
 import {
   loadDashboardAnalytics,
   loadRecommendedTasks,
+  loadDashboardTrajectory,
+  loadUserSkills,
+  setSelectedSkill,
 } from '@app/store/dashboard/dashboard.actions';
 import {
   selectIsDashboardAnalyticsLoading,
@@ -21,6 +32,9 @@ import {
   selectRecommendedTasks,
   selectIsRecommendedTasksLoading,
   selectRecommendedTasksError,
+  selectUserSkills,
+  selectTrajectoryData,
+  selectSelectedSkillId,
 } from '@app/store/dashboard/dashboard.selectors';
 import { selectCurrentUser } from '@app/store/auth/auth.selectors';
 
@@ -52,21 +66,36 @@ import { TourGuide } from '@app/core';
 })
 export class Dashboard implements OnInit, AfterViewInit {
   private user = this.store.selectSignal(selectCurrentUser);
-  public selectedPeriod = signal('weekly');
+  public selectedPeriod = signal(TrajectoryGranularity.WEEKLY);
+  public userSkills = this.store.selectSignal(selectUserSkills);
+  public trajectoryData = this.store.selectSignal(selectTrajectoryData);
 
-  public data = {
-    progressChartData: {
-      weekly: [
-        { label: 'Mon', value: 30 },
-        { label: 'Tue', value: 10 },
-        { label: 'Wed', value: 5 },
-        { label: 'Thu', value: 0 },
-        { label: 'Fri', value: 0 },
-        { label: 'Sat', value: 0 },
-        { label: 'Sun', value: 0 },
-      ],
-    },
-  };
+  public progressChartData = computed(() => {
+    const apiData = this.trajectoryData();
+
+    const startOfWeek = this.getMonday(new Date());
+
+    return Array.from({ length: 7 }).map((_, i) => {
+      const date = new Date(startOfWeek);
+      date.setDate(startOfWeek.getDate() + i);
+
+      const found = apiData?.find(
+        (d) => new Date(d.snapshotDate).toDateString() === date.toDateString(),
+      );
+
+      return {
+        label: date.toLocaleDateString('en-US', { weekday: 'short' }),
+        value: found ? found.averageXpEarned : 0,
+      };
+    });
+  });
+
+  private getMonday(date: Date) {
+    const d = new Date(date);
+    const day = d.getDay();
+    const diff = d.getDate() - day + (day === 0 ? -6 : 1);
+    return new Date(d.setDate(diff));
+  }
 
   public isDashboardAnalyticsLoading = this.store.selectSignal(selectIsDashboardAnalyticsLoading);
   public isDashboardAnalyticsError = this.store.selectSignal(selectDashboardAnalyticsError);
@@ -76,6 +105,7 @@ export class Dashboard implements OnInit, AfterViewInit {
   public recommendedTasks = this.store.selectSignal(selectRecommendedTasks);
   public isRecommendedTasksLoading = this.store.selectSignal(selectIsRecommendedTasksLoading);
   public selectRecommendedTasksError = this.store.selectSignal(selectRecommendedTasksError);
+  public selectedSkillId = this.store.selectSignal(selectSelectedSkillId);
 
   constructor(
     private shepherdService: ShepherdService,
@@ -86,6 +116,7 @@ export class Dashboard implements OnInit, AfterViewInit {
   ngOnInit() {
     this.getDashboardAnalytics();
     this.getRecommendedTasks();
+    this.getUserSkills();
   }
 
   ngAfterViewInit() {
@@ -103,8 +134,12 @@ export class Dashboard implements OnInit, AfterViewInit {
     this.shepherdService.start();
   }
 
-  public selectPeriod(period: string): void {
+  public selectPeriod(period: TrajectoryGranularity): void {
     this.selectedPeriod.set(period);
+  }
+
+  public selectSkill(skill: string): void {
+    this.store.dispatch(setSelectedSkill({ skillId: skill }));
   }
 
   public get userName(): string {
@@ -117,5 +152,39 @@ export class Dashboard implements OnInit, AfterViewInit {
 
   public getRecommendedTasks(): void {
     this.store.dispatch(loadRecommendedTasks());
+  }
+
+  public onSkillChange(skillId: string): void {
+    this.store.dispatch(setSelectedSkill({ skillId }));
+
+    const granularity = this.selectedPeriod();
+    this.store.dispatch(loadDashboardTrajectory({ skillId, granularity }));
+  }
+
+  public onPeriodChange(period: string): void {
+    const granularity = this.mapPeriodToGranularity(period);
+    this.selectedPeriod.set(granularity);
+
+    const skillId = this.selectedSkillId();
+    if (skillId) {
+      this.store.dispatch(loadDashboardTrajectory({ skillId, granularity }));
+    }
+  }
+
+  private mapPeriodToGranularity(period: string): TrajectoryGranularity {
+    switch (period.toLowerCase()) {
+      case 'daily':
+        return TrajectoryGranularity.DAILY;
+      case 'weekly':
+        return TrajectoryGranularity.WEEKLY;
+      case 'monthly':
+        return TrajectoryGranularity.MONTHLY;
+      default:
+        return TrajectoryGranularity.WEEKLY;
+    }
+  }
+
+  public getUserSkills(): void {
+    this.store.dispatch(loadUserSkills());
   }
 }

--- a/src/app/shared/components/progress-chart/progress-chart.html
+++ b/src/app/shared/components/progress-chart/progress-chart.html
@@ -14,5 +14,6 @@
     [roundDomains]="true"
     [autoScale]="true"
     [curve]="curve"
+    [showYAxisLabel]="showYAxisLabel"
   />
 </div>

--- a/src/app/shared/components/progress-chart/progress-chart.ts
+++ b/src/app/shared/components/progress-chart/progress-chart.ts
@@ -47,7 +47,7 @@ export class ProgressChart implements OnChanges {
     name: 'XP',
     domain: ['#4f46e5'],
     selectable: false,
-    group: ScaleType.Time,
+    group: ScaleType.Ordinal,
   };
 
   public schemeType: ScaleType = ScaleType.Ordinal;


### PR DESCRIPTION
**Related Ticket:** Closes [[GSDT 535](https://amali-tech.atlassian.net/browse/GSDT-535)]

**Description** This PR connects the "Your Progress" UI section to the live NgRx store.

Previously, the `ProgressOverviewComponent` was displaying static mock data. It now subscribes to the `userSkills` and `trajectory` selectors to display the user's actual learning path.

**Changes Made**

-   **Smart Component Update:**

    -   Updated `DashboardMainComponent` (or `ProgressOverviewComponent`) to select `selectUserSkills` and `selectTrajectoryData` from the store.

-   **Data Binding:**

    -   Mapped the live trajectory data to the input expected by the `<app-progress-chart>`.

    -   Mapped the active skill details to the `<app-progress-bar>`.

-   **Loading Logic:**

    -   Ensured the skeleton loader remains visible until *both* the skills and the trajectory data have finished loading.

**How to Test**

1.  Pull this branch and run the app.

2.  **Login as a User with Data:**

    -   [ ] Check the "Your Progress" section.

    -   [ ] **Expected:** The chart should render the line graph based on the live trajectory data.

    -   [ ] **Expected:** The skill name and progress bar should reflect the user's primary skill.

3.  **Login as a New User (No Data):**

    -   [ ] **Expected:** The "No progress yet" empty state should appear.