### PR TITLE
feat(GSDT 541): implement task card skeleton for loading state

### DIFF
--- a/src/app/features/tasks-dashboard/components/task-card-skeleton/task-card-skeleton.html
+++ b/src/app/features/tasks-dashboard/components/task-card-skeleton/task-card-skeleton.html
@@ -1,0 +1,24 @@
+<div class="task-card-skeleton">
+  <div class="icon-wrapper-skeleton skeleton"></div>
+  <div class="card-content-skeleton">
+    <div class="title-row-skeleton">
+      <div class="title-group-skeleton">
+        <div class="title-skeleton skeleton"></div>
+        <div class="description-skeleton skeleton"></div>
+      </div>
+      <div class="meta-tags-skeleton">
+        <div class="tag-skeleton skeleton"></div>
+        <div class="tag-skeleton skeleton"></div>
+      </div>
+    </div>
+    <div class="card-footer-skeleton">
+      <div class="details-skeleton">
+        <div class="detail-item-skeleton skeleton"></div>
+        <div class="detail-item-skeleton skeleton"></div>
+      </div>
+    </div>
+    <div class="action-section-skeleton">
+      <div class="start-button-skeleton skeleton"></div>
+    </div>
+  </div>
+</div>

--- a/src/app/features/tasks-dashboard/components/task-card-skeleton/task-card-skeleton.scss
+++ b/src/app/features/tasks-dashboard/components/task-card-skeleton/task-card-skeleton.scss
@@ -1,0 +1,106 @@
+@use 'colors' as *;
+@use 'mixins' as *;
+@use 'skeletons' as *;
+
+.task-card-skeleton {
+  @include flex($direction: row, $align: flex-start, $gap: 11px);
+  width: 100%;
+  height: 100%;
+  padding: 1rem;
+  background-color: $white;
+  border: 1px solid $text-gray;
+  border-radius: 0.25rem;
+}
+
+.icon-wrapper-skeleton {
+  @extend .skeleton-placeholder;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.card-content-skeleton {
+  @include flex($direction: column, $gap: 0.25rem);
+  flex: 1;
+  position: relative;
+}
+
+.title-row-skeleton {
+  @include flex($direction: row, $justify: space-between, $align: flex-start);
+}
+
+.title-group-skeleton {
+  @include flex($direction: column, $gap: 0.25rem);
+  flex: 1;
+}
+
+.title-skeleton {
+  @extend .skeleton-placeholder;
+  height: 1.25rem;
+  width: 70%;
+}
+
+.description-skeleton {
+  @extend .skeleton-placeholder;
+  height: 1rem;
+  width: 90%;
+}
+
+.meta-tags-skeleton {
+  @include flex($direction: row, $align: center, $gap: 0.313rem);
+  flex-shrink: 0;
+
+  .tag-skeleton {
+    @extend .skeleton-placeholder;
+    height: 1rem;
+    width: 2.25rem;
+    border-radius: 1.5rem;
+  }
+}
+
+.card-footer-skeleton {
+  @include flex($direction: column, $align: flex-start, $gap: 0.25rem);
+}
+
+.details-skeleton {
+  @include flex($direction: row, $align: center, $gap: 0.875rem);
+
+  .detail-item-skeleton {
+    @extend .skeleton-placeholder;
+    height: 0.875rem;
+    width: 4rem;
+  }
+}
+
+.action-section-skeleton {
+  width: 100%;
+
+  .start-button-skeleton {
+    @extend .skeleton-placeholder;
+    height: 2.5rem;
+    width: 5rem;
+    border-radius: 0.25rem;
+  }
+}
+
+@include mobile-large {
+  .card-content-skeleton {
+    .card-footer-skeleton {
+      @include flex($direction: row, $justify: space-between, $align: center);
+    }
+
+    .action-section-skeleton {
+      position: absolute;
+      bottom: 0;
+      right: 0;
+      width: auto;
+
+      .start-button-skeleton {
+        width: 5.875rem;
+        height: 2rem;
+        padding: 0.375rem;
+      }
+    }
+  }
+}

--- a/src/app/features/tasks-dashboard/components/task-card-skeleton/task-card-skeleton.spec.ts
+++ b/src/app/features/tasks-dashboard/components/task-card-skeleton/task-card-skeleton.spec.ts
@@ -1,0 +1,37 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TaskCardSkeleton } from './task-card-skeleton';
+
+describe('TaskCardSkeleton', () => {
+  let component: TaskCardSkeleton;
+  let fixture: ComponentFixture<TaskCardSkeleton>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TaskCardSkeleton],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TaskCardSkeleton);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render skeleton elements', () => {
+    const compiled = fixture.nativeElement;
+    expect(compiled.querySelector('.task-card-skeleton')).toBeTruthy();
+    expect(compiled.querySelector('.icon-wrapper-skeleton')).toBeTruthy();
+    expect(compiled.querySelector('.title-skeleton')).toBeTruthy();
+    expect(compiled.querySelector('.description-skeleton')).toBeTruthy();
+    expect(compiled.querySelector('.start-button-skeleton')).toBeTruthy();
+  });
+
+  it('should have skeleton animation class', () => {
+    const compiled = fixture.nativeElement;
+    const skeletonElements = compiled.querySelectorAll('.skeleton');
+    expect(skeletonElements.length).toBeGreaterThan(0);
+  });
+});

--- a/src/app/features/tasks-dashboard/components/task-card-skeleton/task-card-skeleton.ts
+++ b/src/app/features/tasks-dashboard/components/task-card-skeleton/task-card-skeleton.ts
@@ -1,0 +1,9 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+
+@Component({
+  selector: 'app-task-card-skeleton',
+  templateUrl: './task-card-skeleton.html',
+  styleUrl: './task-card-skeleton.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TaskCardSkeleton {}

--- a/src/app/features/tasks-dashboard/components/task-list/task-list.html
+++ b/src/app/features/tasks-dashboard/components/task-list/task-list.html
@@ -1,40 +1,45 @@
 <section class="tasks-list-section">
-  <div class="list-container">
-    <h2 class="list-title">Today's Tasks</h2>
+  @for (section of taskSections(); track section.title) {
+    @let title = section.title;
+    @let tasks = section.tasks;
+    @let emptyMessage = section.emptyMessage;
+    @let showDropdown = section.showDropdown;
+    @let viewState = section.viewState;
 
-    @if (todayTasks().length) {
+    <div class="list-container">
+      @if (showDropdown) {
+        <div class="list-header">
+          <h2 class="list-title">{{ title }}</h2>
+          <app-custom-dropdown
+            [options]="timeRanges()"
+            [selectedValue]="selectedTimeRange()"
+            (selectionChange)="onTimeRangeChange($event)"
+          />
+        </div>
+      } @else {
+        <h2 class="list-title">{{ title }}</h2>
+      }
+
       <div class="cards-wrapper">
-        @for (task of todayTasks(); track task.id) {
-          <app-tasks-card [task]="task" (startTask)="onStartTask($event)" />
+        @switch (viewState) {
+          @case ('loading') {
+            @for (i of skeletonItems; track i) {
+              <app-task-card-skeleton />
+            }
+          }
+          @case ('data') {
+            @for (task of tasks; track task.id) {
+              <app-tasks-card [task]="task" (startTask)="onStartTask($event)" />
+            }
+          }
         }
       </div>
-    } @else {
-      <div class="empty-state">
-        <p class="empty-message">No tasks scheduled for today.</p>
-      </div>
-    }
-  </div>
 
-  <div class="list-container">
-    <div class="list-header">
-      <h2 class="list-title">Previous Tasks</h2>
-      <app-custom-dropdown
-        [options]="timeRanges()"
-        [selectedValue]="selectedTimeRange()"
-        (selectionChange)="onTimeRangeChange($event)"
-      />
+      @if (viewState === 'empty') {
+        <div class="empty-state">
+          <p class="empty-message">{{ emptyMessage }}</p>
+        </div>
+      }
     </div>
-
-    @if (previousTasks().length) {
-      <div class="cards-wrapper">
-        @for (task of previousTasks(); track task.id) {
-          <app-tasks-card [task]="task" (startTask)="onStartTask($event)" />
-        }
-      </div>
-    } @else {
-      <div class="empty-state">
-        <p class="empty-message">No tasks found for the selected time period.</p>
-      </div>
-    }
-  </div>
+  }
 </section>

--- a/src/app/features/tasks-dashboard/components/task-list/task-list.ts
+++ b/src/app/features/tasks-dashboard/components/task-list/task-list.ts
@@ -1,14 +1,25 @@
-import { Component, input, output } from '@angular/core';
+import { Component, input, output, computed } from '@angular/core';
 import { ChangeDetectionStrategy } from '@angular/core';
 import { TaskUI } from '@app/core/models/tasks-model';
 import { TasksCard } from '../tasks-card/tasks-card';
+import { TaskCardSkeleton } from '../task-card-skeleton/task-card-skeleton';
 import { CustomDropdown } from '@app/shared/components/custom-dropdown/custom-dropdown';
 import { selectTimeRanges } from '@app/store/tasks/tasks.selectors';
 import { Store } from '@ngrx/store';
 
+type ViewState = 'loading' | 'empty' | 'data';
+
+interface TaskSection {
+  title: string;
+  tasks: TaskUI[];
+  emptyMessage: string;
+  showDropdown?: boolean;
+  viewState: ViewState;
+}
+
 @Component({
   selector: 'app-task-list',
-  imports: [TasksCard, CustomDropdown],
+  imports: [TasksCard, TaskCardSkeleton, CustomDropdown],
   templateUrl: './task-list.html',
   styleUrl: './task-list.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -19,11 +30,36 @@ export class TaskList {
   public todayTasks = input.required<TaskUI[]>();
   public previousTasks = input.required<TaskUI[]>();
   public selectedTimeRange = input<string | undefined>();
+  public loading = input<boolean>(false);
 
   public timeRangeChanged = output<string>();
   public startTask = output<string>();
 
   public timeRanges = this.store.selectSignal(selectTimeRanges);
+  public skeletonItems = Array.from({ length: 3 });
+
+  public taskSections = computed<TaskSection[]>(() => {
+    const getViewState = (tasks: TaskUI[]): ViewState => {
+      if (this.loading()) return 'loading';
+      return tasks.length ? 'data' : 'empty';
+    };
+
+    return [
+      {
+        title: "Today's Tasks",
+        tasks: this.todayTasks(),
+        emptyMessage: 'No tasks scheduled for today.',
+        viewState: getViewState(this.todayTasks()),
+      },
+      {
+        title: 'Previous Tasks',
+        tasks: this.previousTasks(),
+        emptyMessage: 'No tasks found for the selected time period.',
+        showDropdown: true,
+        viewState: getViewState(this.previousTasks()),
+      },
+    ];
+  });
 
   public onTimeRangeChange(timeRange: string): void {
     this.timeRangeChanged.emit(timeRange);

--- a/src/app/features/tasks-dashboard/tasks-dashboard.html
+++ b/src/app/features/tasks-dashboard/tasks-dashboard.html
@@ -4,6 +4,7 @@
     [todayTasks]="todayTasks()"
     [previousTasks]="previousTasks()"
     [selectedTimeRange]="selectedTimeRangeString"
+    [loading]="loading()"
     (timeRangeChanged)="onTimeRangeChanged($event)"
     (startTask)="onStartTask($event)"
   />

--- a/src/app/features/tasks-dashboard/tasks-dashboard.ts
+++ b/src/app/features/tasks-dashboard/tasks-dashboard.ts
@@ -6,6 +6,7 @@ import {
   selectSkillFilter,
   selectFilteredPreviousTasks,
   selectTimeRangeFilter,
+  selectTasksLoading,
 } from '@app/store/tasks/tasks.selectors';
 import {
   changeSkillFilter,
@@ -34,6 +35,7 @@ export class TasksDashboard implements OnInit {
   public previousTasks = this.store.selectSignal(selectFilteredPreviousTasks);
   public selectedSkill = this.store.selectSignal(selectSkillFilter);
   public selectedTimeRange = this.store.selectSignal(selectTimeRangeFilter);
+  public loading = this.store.selectSignal(selectTasksLoading);
 
   public get selectedTimeRangeString(): string {
     return completedPeriodToString(this.selectedTimeRange());

--- a/src/app/store/tasks/tasks.selectors.ts
+++ b/src/app/store/tasks/tasks.selectors.ts
@@ -162,3 +162,5 @@ export const selectXpEarned = createSelector(
   selectSubmissionResult,
   (result) => result?.xpEarned || 0,
 );
+
+export const selectTasksLoading = createSelector(selectTasksState, ({ loading }) => loading);


### PR DESCRIPTION
This PR introduces a major improvement to the Tasks Dashboard UX by adding a skeleton loading state and refactoring the task list template for cleaner, scalable rendering.

It also unifies the logic for displaying *Today's Tasks* and *Previous Tasks* using a computed `taskSections` structure, significantly reducing template duplication and making the component easier to maintain.

* * * * *

### **Key Changes**

#### **1\. Added Skeleton Loading State**

-   Introduced `<app-task-card-skeleton>` component for a visual loading placeholder.

-   Displayed skeletons when the `loading` input is `true`.

-   Added a new `selectTasksLoading` selector to drive the loading state.

#### **2\. Refactored Task List Template**

-   Replaced manual duplicated section markup with a loop over `taskSections()`.

-   Used Angular's `@for`, `@switch`, and `@case` blocks for cleaner logic control.

-   Unified handling of titles, dropdowns, empty states, and content rendering.

#### **3\. Updated TaskList Component**

-   Added a new `loading` input.

-   Added a computed `taskSections()` array that determines:

    -   title

    -   tasks

    -   empty message

    -   whether dropdown should show

    -   viewState: `'loading' | 'empty' | 'data'`

-   Introduced helper logic for deriving display state based on loading/tasks.

#### **4\. Updated Tasks Dashboard**

-   Passed the loading signal down into `<app-task-list>`.

#### **5\. Improved Maintainability**

-   Reduced code duplication.

-   Centralized section logic.

-   Easier to extend for future improvements (pagination, tabs, filters, etc.).

* * * * *

### **How to Test**

1.  Load the dashboard before tasks resolve.

2.  Confirm skeleton components display instead of task cards.

3.  Confirm that once tasks load:

    -   today tasks show correctly

    -   previous tasks show correctly

4.  Confirm empty states show when there are no tasks.

5.  Verify filter dropdown works as before.

<img width="607" height="822" alt="Screenshot 2025-11-21 092858" src="https://github.com/user-attachments/assets/e98455e0-ad21-416b-9528-97f07bd2aa6e" />
<img width="1919" height="970" alt="Screenshot 2025-11-21 065031" src="https://github.com/user-attachments/assets/f98db5ea-a94a-402a-af9b-8e0b420cf74b" />
