### PR TITLE
feat(GSDT 550): implement page not found when user navigates to a wrong path

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -90,4 +90,9 @@ export const routes: Routes = [
       },
     ],
   },
+  {
+    path: '**',
+    loadComponent: () =>
+      import('./layout/page-not-found/page-not-found').then((c) => c.PageNotFound),
+  },
 ];

--- a/src/app/layout/page-not-found/page-not-found.html
+++ b/src/app/layout/page-not-found/page-not-found.html
@@ -1,0 +1,10 @@
+<div class="not-found-container">
+  <h1>404</h1>
+  <p>Oops! The page you're looking for doesn't exist.</p>
+
+  <div class="button-group">
+    <button (click)="goBack()" class="btn-back">Go Back</button>
+
+    <a routerLink="/" class="btn-home">Go Home</a>
+  </div>
+</div>

--- a/src/app/layout/page-not-found/page-not-found.scss
+++ b/src/app/layout/page-not-found/page-not-found.scss
@@ -1,0 +1,63 @@
+@use 'mixins' as *;
+@use 'typography' as *;
+
+.not-found-container {
+  @include flex($direction: column, $justify: center, $align: center);
+  height: 100vh;
+  text-align: center;
+  background-color: var(--color-white);
+  padding: var(--space-md);
+}
+h1 {
+  @include h3;
+  margin: 0;
+  color: var(--color-gray-text-strong);
+  line-height: 1;
+}
+p {
+  @include h13;
+  color: var(--color-gray-text-weak);
+  margin-bottom: var(--space-xl);
+}
+
+.button-group {
+  @include flex($direction: row, $gap: var(--space-md));
+}
+
+.btn-home,
+.btn-back {
+  padding: 0.75rem 1.5rem;
+  border-radius: 6px;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+  border: none;
+  font-size: 1rem;
+  transition: background-color 0.2s;
+}
+
+.btn-home {
+  background-color: var(--color-brand-text);
+  color: var(--color-white);
+}
+.btn-home:hover {
+  background-color: var(--color-brand-stroke-strong);
+}
+
+.btn-back {
+  background-color: var(--color-white);
+  color: var(--color-gray-text-strong);
+  border: 1px solid var(--color-gray-stroke-weak);
+}
+.btn-back:hover {
+  background-color: var(--color-gray-fill);
+}
+
+@include tablet {
+  h1 {
+    @include h1;
+  }
+  p {
+    @include h12;
+  }
+}

--- a/src/app/layout/page-not-found/page-not-found.spec.ts
+++ b/src/app/layout/page-not-found/page-not-found.spec.ts
@@ -1,0 +1,53 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Location } from '@angular/common';
+import { RouterTestingModule } from '@angular/router/testing';
+import { By } from '@angular/platform-browser';
+import { RouterLink } from '@angular/router';
+
+import { PageNotFound } from './page-not-found';
+
+describe('PageNotFound', () => {
+  let component: PageNotFound;
+  let fixture: ComponentFixture<PageNotFound>;
+  let mockLocation: { back: jest.Mock };
+
+  beforeEach(async () => {
+    mockLocation = { back: jest.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [PageNotFound, RouterTestingModule],
+      providers: [{ provide: Location, useValue: mockLocation }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PageNotFound);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should call location.back when goBack is called', () => {
+    component.goBack();
+    expect(mockLocation.back).toHaveBeenCalled();
+  });
+
+  it('should call location.back the expected number of times', () => {
+    component.goBack();
+    component.goBack();
+    expect(mockLocation.back).toHaveBeenCalledTimes(2);
+  });
+
+  it('should render router links in the template', () => {
+    const links = fixture.debugElement.queryAll(By.directive(RouterLink));
+    expect(links.length).toBeGreaterThan(0);
+  });
+
+  it('should call location.back when the primary back button is clicked', () => {
+    const backButton = fixture.debugElement.query(By.css('button'));
+    expect(backButton).toBeTruthy();
+    backButton.triggerEventHandler('click', null);
+    expect(mockLocation.back).toHaveBeenCalled();
+  });
+});

--- a/src/app/layout/page-not-found/page-not-found.ts
+++ b/src/app/layout/page-not-found/page-not-found.ts
@@ -1,0 +1,18 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { Location } from '@angular/common';
+
+@Component({
+  selector: 'app-page-not-found',
+  imports: [RouterLink],
+  templateUrl: './page-not-found.html',
+  styleUrl: './page-not-found.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PageNotFound {
+  constructor(private location: Location) {}
+
+  public goBack(): void {
+    this.location.back();
+  }
+}


### PR DESCRIPTION
This PR introduces a 404 page that displays when a user routes to a non existing page or path within the application.

<img width="1920" height="985" alt="Screenshot 2025-11-23 at 8 13 55 AM" src="https://github.com/user-attachments/assets/d0f46fd4-527b-4547-85d2-877422f3caf9" />
