### PR TITLE
feat(GSDT 551): implement coming soon page for components

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -88,6 +88,19 @@ export const routes: Routes = [
         loadComponent: () =>
           import('./features/multiple-choice/multiple-choice').then((c) => c.MultipleChoice),
       },
+      {
+        path: 'leaderboard',
+        loadComponent: () =>
+          import('./features/leaderboard/leaderboard').then((c) => c.Leaderboard),
+      },
+      {
+        path: 'skill-arena',
+        loadComponent: () => import('./features/skill-arena/skill-arena').then((c) => c.SkillArena),
+      },
+      {
+        path: 'groups',
+        loadComponent: () => import('./features/groups/groups').then((c) => c.Groups),
+      },
     ],
   },
 ];

--- a/src/app/features/groups/groups.html
+++ b/src/app/features/groups/groups.html
@@ -1,0 +1,1 @@
+<app-coming-soon title="Groups - Coming Soon" />

--- a/src/app/features/groups/groups.spec.ts
+++ b/src/app/features/groups/groups.spec.ts
@@ -1,0 +1,29 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { Groups } from './groups';
+import { ComingSoon } from '@app/shared/components/coming-soon/coming-soon';
+
+describe('Groups Component', () => {
+  let component: Groups;
+  let fixture: ComponentFixture<Groups>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [Groups, ComingSoon],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {},
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Groups);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/groups/groups.ts
+++ b/src/app/features/groups/groups.ts
@@ -1,0 +1,10 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ComingSoon } from '@app/shared/components/coming-soon/coming-soon';
+
+@Component({
+  selector: 'app-groups',
+  imports: [ComingSoon],
+  templateUrl: './groups.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class Groups {}

--- a/src/app/features/leaderboard/leaderboard.html
+++ b/src/app/features/leaderboard/leaderboard.html
@@ -1,0 +1,1 @@
+<app-coming-soon title="Leaderboard - Coming Soon" />

--- a/src/app/features/leaderboard/leaderboard.spec.ts
+++ b/src/app/features/leaderboard/leaderboard.spec.ts
@@ -1,0 +1,29 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { Leaderboard } from './leaderboard';
+import { ComingSoon } from '@app/shared/components/coming-soon/coming-soon';
+
+describe('Leaderboard', () => {
+  let component: Leaderboard;
+  let fixture: ComponentFixture<Leaderboard>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [Leaderboard, ComingSoon],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {},
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Leaderboard);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/leaderboard/leaderboard.ts
+++ b/src/app/features/leaderboard/leaderboard.ts
@@ -1,0 +1,10 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ComingSoon } from '@app/shared/components/coming-soon/coming-soon';
+
+@Component({
+  selector: 'app-leaderboard',
+  imports: [ComingSoon],
+  templateUrl: './leaderboard.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class Leaderboard {}

--- a/src/app/features/skill-arena/skill-arena.html
+++ b/src/app/features/skill-arena/skill-arena.html
@@ -1,0 +1,1 @@
+<app-coming-soon title="Skill Arena - Coming Soon" />

--- a/src/app/features/skill-arena/skill-arena.spec.ts
+++ b/src/app/features/skill-arena/skill-arena.spec.ts
@@ -1,0 +1,29 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { SkillArena } from './skill-arena';
+import { ComingSoon } from '@app/shared/components/coming-soon/coming-soon';
+
+describe('SkillArena', () => {
+  let component: SkillArena;
+  let fixture: ComponentFixture<SkillArena>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SkillArena, ComingSoon],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {},
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SkillArena);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/skill-arena/skill-arena.ts
+++ b/src/app/features/skill-arena/skill-arena.ts
@@ -1,0 +1,10 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ComingSoon } from '@app/shared/components/coming-soon/coming-soon';
+
+@Component({
+  selector: 'app-skill-arena',
+  imports: [ComingSoon],
+  templateUrl: './skill-arena.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SkillArena {}

--- a/src/app/layout/dashboard/dashboard.ts
+++ b/src/app/layout/dashboard/dashboard.ts
@@ -39,12 +39,6 @@ export class Dashboard implements OnInit {
       tourId: 'sidebar-skill-arena',
     },
     {
-      icon: 'star',
-      label: 'Badges',
-      route: '/dashboard/achievements',
-      tourId: 'sidebar-achievements',
-    },
-    {
       icon: 'users',
       label: 'Groups',
       route: '/dashboard/groups',

--- a/src/app/shared/components/coming-soon/coming-soon.html
+++ b/src/app/shared/components/coming-soon/coming-soon.html
@@ -1,0 +1,10 @@
+<div class="coming-soon-container">
+  <div class="content-wrapper">
+    <h1 class="title">{{ title }}</h1>
+    <p class="description">{{ description }}</p>
+
+    <div class="actions">
+      <a routerLink="/dashboard" class="btn-primary">Back to Dashboard</a>
+    </div>
+  </div>
+</div>

--- a/src/app/shared/components/coming-soon/coming-soon.scss
+++ b/src/app/shared/components/coming-soon/coming-soon.scss
@@ -1,0 +1,55 @@
+@use 'mixins' as *;
+
+$primary-color: #3366ff;
+$bg-color: #fff;
+$text-dark: #1f2937;
+$text-light: #6b7280;
+$white: #ffffff;
+
+:host {
+  display: block;
+  height: 100%;
+  width: 100%;
+}
+
+.coming-soon-container {
+  @include flex($direction: row, $justify: center, $align: center);
+  min-height: 95vh;
+  padding: 2rem;
+  background-color: $bg-color;
+  border-radius: 12px;
+}
+
+.content-wrapper {
+  text-align: center;
+}
+
+.title {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: $text-dark;
+  margin: 0 0 1rem 0;
+  line-height: 1.2;
+}
+
+.description {
+  font-size: 1.125rem;
+  color: $text-light;
+  margin: 0 0 2.5rem 0;
+  line-height: 1.6;
+}
+
+.btn-primary {
+  display: inline-block;
+  background-color: $primary-color;
+  color: $white;
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background-color: var(--color-brand-stroke-strong);
+  }
+}

--- a/src/app/shared/components/coming-soon/coming-soon.spec.ts
+++ b/src/app/shared/components/coming-soon/coming-soon.spec.ts
@@ -1,0 +1,52 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { By } from '@angular/platform-browser';
+
+import { ComingSoon } from './coming-soon';
+
+describe('ComingSoon', () => {
+  let component: ComingSoon;
+  let fixture: ComponentFixture<ComingSoon>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ComingSoon],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {},
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ComingSoon);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should have default title and description', () => {
+    expect(component.title).toBe('Coming Soon');
+    expect(component.description).toBe('Stay tuned for updates!');
+  });
+
+  it('should display the title and description in the template', () => {
+    component.title = 'New Feature';
+    component.description = 'Details coming soon!';
+    fixture.detectChanges();
+
+    const titleElement = fixture.debugElement.query(By.css('h1'));
+    const descriptionElement = fixture.debugElement.query(By.css('p'));
+
+    expect(titleElement.nativeElement.textContent).toBeDefined();
+    expect(descriptionElement.nativeElement.textContent).toBeDefined();
+  });
+
+  it('should accept an iconName input', () => {
+    component.iconName = 'star';
+    expect(component.iconName).toBe('star');
+  });
+});

--- a/src/app/shared/components/coming-soon/coming-soon.ts
+++ b/src/app/shared/components/coming-soon/coming-soon.ts
@@ -1,0 +1,16 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-coming-soon',
+  imports: [RouterLink],
+  templateUrl: './coming-soon.html',
+  styleUrl: './coming-soon.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ComingSoon {
+  @Input() public title: string = 'Coming Soon';
+  @Input() public description: string = 'Stay tuned for updates!';
+
+  @Input() public iconName: string = 'rocket';
+}


### PR DESCRIPTION
This PR introduces a coming soon component for pages that are to be implemented soon.

<img width="1920" height="995" alt="Screenshot 2025-11-23 at 8 09 29 AM" src="https://github.com/user-attachments/assets/69b7cfdb-4b1b-4eac-9ab0-84b85813bb45" />
