### PR TITLE
feat(GSDT 552): implement authenticated homepage navigation

### DIFF
--- a/src/app/features/landing-page/components/hero-section/hero-section.html
+++ b/src/app/features/landing-page/components/hero-section/hero-section.html
@@ -1,35 +1,35 @@
 <section class="hero-container">
+  <div class="hero-content">
+    <section class="hero-text">
+      <h1 class="hero-title">Master Your Technical Skills with Personalized AI Practice</h1>
 
-    <div class="hero-content">
-        <section class="hero-text">
-            <h1 class="hero-title">
-                Master Your Technical Skills with Personalized AI Practice
-            </h1>
+      <p class="hero-subtitle">
+        Ready to advance your career or just sharpen your tech abilities? Effective practice is key,
+        but finding relevant challenges and getting actionable feedback can be tough.
+      </p>
+    </section>
 
-            <p class="hero-subtitle">
-                Ready to advance your career or just sharpen your tech abilities? Effective practice is key,
-                but finding relevant challenges and getting actionable feedback can be tough.
-            </p>
-        </section>
+    <section class="hero-bottom">
+      <div class="social-proof">
+        <img class="avatars" src="assets/avatar-collection.png" alt="avatars" />
+        <div class="proof-count">
+          <p class="count">10k +</p>
+          <p class="users">Users</p>
+        </div>
+      </div>
 
-        <section class="hero-bottom">
-            <div class="social-proof">
-                <img class="avatars" src="assets/avatar-collection.png" alt="avatars">
-                <div class="proof-count">
-                    <p class="count">10k +</p>
-                    <p class="users">Users</p>
-                </div>
-            </div>
+      <div class="hero-actions">
+        @if (isAuthenticated()) {
+          <button class="btn-primary" (click)="navigateToDashboard()">Go to Dashboard</button>
+        } @else {
+          <button class="btn-primary" (click)="navigateToSignup()">Start Practicing Free</button>
+        }
+        <button class="btn-outline" (click)="scrollToFeatures()">Learn More</button>
+      </div>
+    </section>
+  </div>
 
-            <div class="hero-actions">
-                <button class="btn-primary" (click)="navigateToSignup()">Start Practicing Free</button>
-                <button class="btn-outline" (click)="scrollToFeatures()">Learn More</button>
-            </div>
-        </section>
-
-    </div>
-
-    <div class="hero-visual">
-        <img src="assets/hero-image.png" class="visual-placeholder" alt="hero-image">
-    </div>
+  <div class="hero-visual">
+    <img src="assets/hero-image.png" class="visual-placeholder" alt="hero-image" />
+  </div>
 </section>

--- a/src/app/features/landing-page/components/hero-section/hero-section.spec.ts
+++ b/src/app/features/landing-page/components/hero-section/hero-section.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
+import { Store } from '@ngrx/store';
 import { HeroSection } from './hero-section';
 import { APP_CONSTANTS } from '@app/core/constants/app.constants';
 
@@ -7,15 +8,23 @@ describe('HeroSection', () => {
   let component: HeroSection;
   let fixture: ComponentFixture<HeroSection>;
   let compiled: HTMLElement;
+  let mockStore: Partial<Store>;
 
   beforeEach(async () => {
     const routerSpy = {
       navigateByUrl: jest.fn(),
     };
 
+    mockStore = {
+      selectSignal: jest.fn().mockReturnValue(() => false),
+    };
+
     await TestBed.configureTestingModule({
       imports: [HeroSection],
-      providers: [{ provide: Router, useValue: routerSpy }],
+      providers: [
+        { provide: Router, useValue: routerSpy },
+        { provide: Store, useValue: mockStore },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(HeroSection);

--- a/src/app/features/landing-page/components/hero-section/hero-section.ts
+++ b/src/app/features/landing-page/components/hero-section/hero-section.ts
@@ -1,5 +1,7 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { Router } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { selectIsAuthenticated } from '@app/store/auth/auth.selectors';
 import { APP_CONSTANTS } from '@app/core/constants/app.constants';
 
 @Component({
@@ -9,10 +11,19 @@ import { APP_CONSTANTS } from '@app/core/constants/app.constants';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class HeroSection {
-  constructor(private router: Router) {}
+  public isAuthenticated = this.store.selectSignal(selectIsAuthenticated);
+
+  constructor(
+    private router: Router,
+    private store: Store,
+  ) {}
 
   public navigateToSignup(): void {
     this.router.navigateByUrl(APP_CONSTANTS.APP_ROUTES.SIGNUP);
+  }
+
+  public navigateToDashboard(): void {
+    this.router.navigateByUrl(APP_CONSTANTS.APP_ROUTES.DASHBOARD);
   }
 
   public scrollToFeatures(): void {

--- a/src/app/shared/compomonents/navigation/navigation.html
+++ b/src/app/shared/compomonents/navigation/navigation.html
@@ -14,8 +14,12 @@
       </div>
 
       <div class="nav-actions">
-        <a routerLink="/login" class="login-btn">Login</a>
-        <button routerLink="/signup" class="signup-btn">Sign Up</button>
+        @if (isAuthenticated()) {
+          <button (click)="navigateToDashboard()" class="dashboard-btn">Go to Dashboard</button>
+        } @else {
+          <a routerLink="/login" class="login-btn">Login</a>
+          <button routerLink="/signup" class="signup-btn">Sign Up</button>
+        }
       </div>
 
       <button class="hamburger" (click)="toggleMenu()">
@@ -43,7 +47,13 @@
   </div>
 
   <div class="mobile-actions">
-    <a routerLink="/login" class="mobile-login" (click)="toggleMenu()">Login</a>
-    <a routerLink="/signup" class="mobile-signup" (click)="toggleMenu()">Sign Up</a>
+    @if (isAuthenticated()) {
+      <button (click)="navigateToDashboard(); toggleMenu()" class="mobile-login">
+        Go to Dashboard
+      </button>
+    } @else {
+      <a routerLink="/login" class="mobile-login" (click)="toggleMenu()">Login</a>
+      <a routerLink="/signup" class="mobile-signup" (click)="toggleMenu()">Sign Up</a>
+    }
   </div>
 </div>

--- a/src/app/shared/compomonents/navigation/navigation.scss
+++ b/src/app/shared/compomonents/navigation/navigation.scss
@@ -51,9 +51,7 @@ a[href^='#']:target {
 }
 
 .nav-actions {
-  display: none;
-  align-items: center;
-  gap: 24px;
+  @include flex($align: center, $gap: 1.5rem);
 
   .dashboard-btn {
     @include button-transparent;

--- a/src/app/shared/compomonents/navigation/navigation.scss
+++ b/src/app/shared/compomonents/navigation/navigation.scss
@@ -54,6 +54,10 @@ a[href^='#']:target {
   display: none;
   align-items: center;
   gap: 24px;
+
+  .dashboard-btn {
+    @include button-transparent;
+  }
 }
 
 .login-btn {

--- a/src/app/shared/compomonents/navigation/navigation.spec.ts
+++ b/src/app/shared/compomonents/navigation/navigation.spec.ts
@@ -1,0 +1,98 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Store } from '@ngrx/store';
+import { Navigation } from './navigation';
+
+describe('Navigation', () => {
+  let component: Navigation;
+  let fixture: ComponentFixture<Navigation>;
+  let mockStore: Partial<Store>;
+
+  beforeEach(async () => {
+    mockStore = {
+      selectSignal: jest.fn().mockReturnValue(() => false),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [Navigation, RouterTestingModule],
+      providers: [{ provide: Store, useValue: mockStore }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Navigation);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should show unauthenticated state by default', () => {
+    expect(component.isAuthenticated()).toBe(false);
+  });
+
+  it('should toggle mobile menu', () => {
+    expect(component.isMobileMenuOpen).toBe(false);
+
+    component.toggleMenu();
+    expect(component.isMobileMenuOpen).toBe(true);
+
+    component.toggleMenu();
+    expect(component.isMobileMenuOpen).toBe(false);
+  });
+
+  it('should call navigateToDashboard method', () => {
+    const navigateSpy = jest.spyOn(component, 'navigateToDashboard');
+    component.navigateToDashboard();
+    expect(navigateSpy).toHaveBeenCalled();
+  });
+
+  it('should navigate to login when login link clicked', () => {
+    const loginLink = fixture.nativeElement.querySelector('a[routerLink="/login"]');
+    expect(loginLink).toBeTruthy();
+    expect(loginLink.getAttribute('routerLink')).toBe('/login');
+  });
+
+  it('should navigate to signup when signup button clicked', () => {
+    const signupBtn = fixture.nativeElement.querySelector('button[routerLink="/signup"]');
+    expect(signupBtn).toBeTruthy();
+    expect(signupBtn.getAttribute('routerLink')).toBe('/signup');
+  });
+
+  it('should show dashboard button when authenticated', () => {
+    mockStore.selectSignal = jest.fn().mockReturnValue(() => true);
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [Navigation, RouterTestingModule],
+      providers: [{ provide: Store, useValue: mockStore }],
+    });
+
+    const authFixture = TestBed.createComponent(Navigation);
+    authFixture.detectChanges();
+
+    const dashboardBtn = authFixture.nativeElement.querySelector('.dashboard-btn');
+    expect(dashboardBtn).toBeTruthy();
+  });
+
+  it('should hide signup button when authenticated', () => {
+    mockStore.selectSignal = jest.fn().mockReturnValue(() => true);
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [Navigation, RouterTestingModule],
+      providers: [{ provide: Store, useValue: mockStore }],
+    });
+
+    const authFixture = TestBed.createComponent(Navigation);
+    authFixture.detectChanges();
+
+    const signupBtn = authFixture.nativeElement.querySelector('button[routerLink="/signup"]');
+    expect(signupBtn).toBeFalsy();
+  });
+
+  it('should show only logo on minimal routes', () => {
+    component['updateShowOnlyLogo']('/login');
+    expect(component.showOnlyLogo).toBe(true);
+  });
+});

--- a/src/app/shared/compomonents/navigation/navigation.ts
+++ b/src/app/shared/compomonents/navigation/navigation.ts
@@ -8,6 +8,9 @@ import {
 import { CommonModule } from '@angular/common';
 import { Router, NavigationEnd, RouterLink } from '@angular/router';
 import { Subject, filter, takeUntil } from 'rxjs';
+import { Store } from '@ngrx/store';
+import { selectIsAuthenticated } from '@app/store/auth/auth.selectors';
+import { APP_CONSTANTS } from '@app/core/constants/app.constants';
 
 @Component({
   selector: 'app-navigation',
@@ -20,6 +23,7 @@ import { Subject, filter, takeUntil } from 'rxjs';
 export class Navigation implements OnInit, OnDestroy {
   public isMobileMenuOpen = false;
   public showOnlyLogo = false;
+  public isAuthenticated = this.store.selectSignal(selectIsAuthenticated);
 
   public readonly minimalLogoRoutes = [
     '/login',
@@ -41,6 +45,7 @@ export class Navigation implements OnInit, OnDestroy {
   constructor(
     private router: Router,
     private cdr: ChangeDetectorRef,
+    private store: Store,
   ) {}
 
   ngOnInit(): void {
@@ -78,5 +83,9 @@ export class Navigation implements OnInit, OnDestroy {
 
   public toggleMenu(): void {
     this.isMobileMenuOpen = !this.isMobileMenuOpen;
+  }
+
+  public navigateToDashboard(): void {
+    this.router.navigateByUrl(APP_CONSTANTS.APP_ROUTES.DASHBOARD);
   }
 }

--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -51,8 +51,7 @@
 
 @mixin button-transparent {
   @include button-base;
-  background-color: $gray-fill;
-  border: 2px solid $gray-fill !important;
+  background-color: transparent;
   color: $brand-text;
 
   &:hover {


### PR DESCRIPTION
Updates homepage navigation and hero section to show contextual buttons based on user authentication state.

### **Changes**

**Navigation Component:**

-   Hide `Sign Up` and `Login` buttons for authenticated users.

-   Display `Go to Dashboard` button when the user is authenticated.

-   Add navigation logic to route authenticated users to the dashboard.

**Hero Section Component:**

-   Replace `Start Practicing Free` with `Go to Dashboard` for authenticated users.

-   Maintain existing behavior for unauthenticated users.

**Styling:**

-   Added proper button styling for dashboard navigation.

**Impact**\
Improves user experience by providing relevant navigation options based on authentication state, reducing confusion for logged-in users visiting the homepage.

<img width="1919" height="960" alt="Screenshot 2025-11-22 221751" src="https://github.com/user-attachments/assets/1a7c8275-d68a-4bb6-979d-b3b1b0db9e5a" />
