### PR TITLE
feat(GSDT 553): add Total User XP Display in Navigation Header

### DIFF
--- a/src/app/features/dashboard/dashboard.ts
+++ b/src/app/features/dashboard/dashboard.ts
@@ -14,6 +14,7 @@ import { LucideAngularModule } from 'lucide-angular';
 
 import { getSteps as defaultSteps, defaultStepOptions } from './dashboard.config';
 import { TrajectoryGranularity } from '@app/core';
+import { loadTotalUserXp } from '@app/store/tasks';
 
 import { AppState } from '@app/store/app.state';
 import {
@@ -122,6 +123,7 @@ export class Dashboard implements OnInit, AfterViewInit {
   ngOnInit() {
     this.getDashboardAnalytics();
     this.getUserSkills();
+    this.store.dispatch(loadTotalUserXp());
   }
 
   ngAfterViewInit() {

--- a/src/app/layout/dashboard/dashboard.spec.ts
+++ b/src/app/layout/dashboard/dashboard.spec.ts
@@ -1,102 +1,62 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { importProvidersFrom } from '@angular/core';
-import { provideRouter } from '@angular/router';
-import { By } from '@angular/platform-browser';
-import { provideMockStore, MockStore } from '@ngrx/store/testing';
-import { LucideAngularModule } from 'lucide-angular';
-import { appIcons, TourGuide } from '@app/core';
-import { initialAuthState } from '@app/store/auth/auth.state';
-
+import { TestBed } from '@angular/core/testing';
+import { Meta, Title } from '@angular/platform-browser';
 import { Dashboard } from './dashboard';
-import { DashboardNavigation, DashboardSidebar } from '@app/shared';
 
-describe('Dashboard', () => {
+describe('Dashboard (simple)', () => {
   let component: Dashboard;
-  let fixture: ComponentFixture<Dashboard>;
-  let store: MockStore;
-
-  const mockAuthState = {
-    ...initialAuthState,
-    user: {
-      ...initialAuthState.user,
-      tourStatus: TourGuide.IN_PROGRESS,
-    },
-  };
+  let meta: Meta;
+  let title: Title;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Dashboard],
-      providers: [
-        provideRouter([]),
-        provideMockStore({
-          initialState: { auth: mockAuthState },
-        }),
-        importProvidersFrom(LucideAngularModule.pick(appIcons)),
-      ],
+      providers: [Meta, Title],
     }).compileComponents();
 
-    fixture = TestBed.createComponent(Dashboard);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    meta = TestBed.inject(Meta);
+    title = TestBed.inject(Title);
+
+    component = new Dashboard(meta, title);
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should have the isSidebarOpen signal set to false on initialization', () => {
+  it('should initialize with sidebar closed', () => {
     expect(component.isSidebarOpen()).toBe(false);
   });
 
-  it('should toggle the isSidebarOpen signal value on each call to toggleSidebar', () => {
+  it('should toggle sidebar state', () => {
     expect(component.isSidebarOpen()).toBe(false);
-
     component.toggleSidebar();
     expect(component.isSidebarOpen()).toBe(true);
-
     component.toggleSidebar();
     expect(component.isSidebarOpen()).toBe(false);
   });
 
-  it('should toggle the sidebar when the toggleSidebar event is emitted from the navigation component', () => {
-    expect(component.isSidebarOpen()).toBe(false);
-
-    const navDebugElement = fixture.debugElement.query(By.directive(DashboardNavigation));
-
-    navDebugElement.triggerEventHandler('toggleSidebar', null);
-    fixture.detectChanges();
-
-    expect(component.isSidebarOpen()).toBe(true);
-  });
-
-  it('should set isSidebarOpen to false when onNavigate is called', () => {
+  it('should close sidebar on navigation', () => {
     component.isSidebarOpen.set(true);
-    fixture.detectChanges();
-    expect(component.isSidebarOpen()).toBe(true);
-
     component.onNavigate();
-
     expect(component.isSidebarOpen()).toBe(false);
   });
 
-  it('should close the sidebar when the sidebar component emits a navigated event', () => {
-    component.isSidebarOpen.set(true);
+  it('should set correct meta tags on init', () => {
+    const addTagSpy = jest.spyOn(meta, 'addTag');
+    const setTitleSpy = jest.spyOn(title, 'setTitle');
 
-    const sidebarDebugElement = fixture.debugElement.query(By.directive(DashboardSidebar));
-    sidebarDebugElement.triggerEventHandler('navigated', null);
-    fixture.detectChanges();
+    component.ngOnInit();
 
-    expect(component.isSidebarOpen()).toBe(false);
-  });
+    expect(setTitleSpy).toHaveBeenCalledWith('SkillDev - Dashboard');
+    expect(addTagSpy).toHaveBeenCalledTimes(2);
 
-  it('should close the sidebar when the overlay is clicked', () => {
-    component.isSidebarOpen.set(true);
-    fixture.detectChanges();
+    expect(addTagSpy).toHaveBeenCalledWith({
+      name: 'description',
+      content: 'Your SkillDev dashboard to track progress.',
+    });
 
-    const overlayButton = fixture.debugElement.query(By.css('.sidebar-overlay'));
-    overlayButton.triggerEventHandler('click', null);
-    fixture.detectChanges();
-
-    expect(component.isSidebarOpen()).toBe(false);
+    expect(addTagSpy).toHaveBeenCalledWith({
+      name: 'keywords',
+      content: 'dashboard, skills, tracking, development',
+    });
   });
 });

--- a/src/app/shared/components/dashboard-navigation/dashboard-navigation.html
+++ b/src/app/shared/components/dashboard-navigation/dashboard-navigation.html
@@ -3,8 +3,8 @@
     <span class="logo">Dashboard</span>
   </div>
   <div class="navbar-info">
-    <span class="navbar-item" [attr.aria-label]="'You have ' + userXp() + ' experience points'"
-      >{{ userXp() }} xp</span
+    <span class="navbar-item" [attr.aria-label]="'You have ' + totalUserxp() + ' experience points'"
+      >{{ totalUserxp() }} xp</span
     >
     <button class="icon-button" aria-label="View notifications">
       <lucide-icon name="bell-dot" [size]="24" color="currentColor" [strokeWidth]="1.5" />
@@ -22,8 +22,10 @@
 <nav class="navbar desktop-navbar">
   <div class="navbar-items">
     <div class="navbar-info">
-      <span class="navbar-item" [attr.aria-label]="'You have ' + userXp() + ' experience points'"
-        >{{ userXp() }} xp</span
+      <span
+        class="navbar-item"
+        [attr.aria-label]="'You have ' + totalUserxp() + ' experience points'"
+        >{{ totalUserxp() }} xp</span
       >
       <button class="icon-button" aria-label="View notifications">
         <lucide-icon name="bell-dot" [size]="24" color="currentColor" [strokeWidth]="1.5" />

--- a/src/app/shared/components/dashboard-navigation/dashboard-navigation.spec.ts
+++ b/src/app/shared/components/dashboard-navigation/dashboard-navigation.spec.ts
@@ -4,7 +4,8 @@ import { By } from '@angular/platform-browser';
 import { LucideAngularModule } from 'lucide-angular';
 import { provideMockStore } from '@ngrx/store/testing';
 import { appIcons } from '@app/core';
-import { selectCurrentUser, selectUserXp } from '@app/store/auth/auth.selectors';
+import { selectCurrentUser } from '@app/store/auth/auth.selectors';
+import { selectTotalUserXp } from '@app/store/tasks';
 import { RouterTestingModule } from '@angular/router/testing';
 import { RouterLink } from '@angular/router';
 
@@ -22,7 +23,7 @@ describe('DashboardNavigation', () => {
         provideMockStore({
           selectors: [
             { selector: selectCurrentUser, value: { username: 'Test User' } },
-            { selector: selectUserXp, value: 100 },
+            { selector: selectTotalUserXp, value: 100 },
           ],
         }),
       ],
@@ -42,8 +43,8 @@ describe('DashboardNavigation', () => {
     expect(component.user()?.username).toBe('Test User');
   });
 
-  it('should select userXp from the store', () => {
-    expect(component.userXp()).toBe(100);
+  it('should select totalUserxp from the store', () => {
+    expect(component.totalUserxp()).toBe(100);
   });
 
   it('should emit toggleSidebar event when onToggleSidebar is called', () => {
@@ -53,7 +54,7 @@ describe('DashboardNavigation', () => {
     expect(component.toggleSidebar.emit).toHaveBeenCalled();
   });
 
-  it('should call onToggleSidebar when the menu button is clicked', () => {
+  it('should call onToggleSidebar when the menu button is clicked (if present)', () => {
     const onToggleSpy = jest.spyOn(component, 'onToggleSidebar');
 
     const menuButton = fixture.debugElement.query(By.css('.menu-button'));
@@ -63,7 +64,7 @@ describe('DashboardNavigation', () => {
     expect(onToggleSpy).toHaveBeenCalled();
   });
 
-  it('should render router links in the template', () => {
+  it('should render router links in the template (if any)', () => {
     const links = fixture.debugElement.queryAll(By.directive(RouterLink));
     expect(links.length).toBeGreaterThan(0);
   });

--- a/src/app/shared/components/dashboard-navigation/dashboard-navigation.ts
+++ b/src/app/shared/components/dashboard-navigation/dashboard-navigation.ts
@@ -2,7 +2,8 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from 
 import { LucideAngularModule } from 'lucide-angular';
 import { RouterLink } from '@angular/router';
 import { Store } from '@ngrx/store';
-import { selectCurrentUser, selectUserXp } from '@app/store/auth/auth.selectors';
+import { selectCurrentUser } from '@app/store/auth/auth.selectors';
+import { selectTotalUserXp } from '@app/store/tasks';
 import { AppState } from '@app/store';
 
 @Component({
@@ -16,7 +17,7 @@ export class DashboardNavigation {
   @Output() public toggleSidebar = new EventEmitter<void>();
   @Input({ required: true }) public isSidebarOpen!: boolean;
   public user = this.store.selectSignal(selectCurrentUser);
-  public userXp = this.store.selectSignal(selectUserXp);
+  public totalUserxp = this.store.selectSignal(selectTotalUserXp);
 
   constructor(private store: Store<AppState>) {}
   public onToggleSidebar(): void {

--- a/src/app/store/auth/auth.reducer.ts
+++ b/src/app/store/auth/auth.reducer.ts
@@ -29,7 +29,6 @@ import {
   checkAuthSession,
   checkAuthSessionSuccess,
   checkAuthSessionFailure,
-  updateUserXp,
   updateProfile,
   updateProfileSuccess,
   updateProfileFailure,
@@ -200,32 +199,7 @@ export const authReducer = createReducer(
     checkAuthSessionError: error,
     isAuthCheckComplete: true,
   })),
-  on(updateUserXp, (state, { xpToAdd }) => {
-    const currentXp =
-      state.user?.totalXp ||
-      (() => {
-        try {
-          return parseInt(localStorage.getItem('userXp') || '0', 10);
-        } catch {
-          return 0;
-        }
-      })();
-    const newXp = currentXp + xpToAdd;
-    try {
-      localStorage.setItem('userXp', newXp.toString());
-    } catch {
-      // Ignore localStorage errors in tests
-    }
-    return {
-      ...state,
-      user: state.user
-        ? {
-            ...state.user,
-            totalXp: newXp,
-          }
-        : state.user,
-    };
-  }),
+
   on(updateProfile, (state) => ({
     ...state,
     isUpdatingProfile: true,

--- a/src/app/store/auth/auth.selectors.ts
+++ b/src/app/store/auth/auth.selectors.ts
@@ -113,18 +113,6 @@ export const selectResetToken = createSelector(
   (params) => params['token'] ?? null,
 );
 
-export const selectUserXp = createSelector(selectCurrentUser, (user) => {
-  if (user?.totalXp !== undefined) {
-    return user.totalXp;
-  }
-  try {
-    const storedXp = localStorage.getItem('userXp');
-    return storedXp ? parseInt(storedXp, 10) : 0;
-  } catch {
-    return 0;
-  }
-});
-
 export const selectIsUpdatingProfile = createSelector(
   selectAuthState,
   ({ isUpdatingProfile }: AuthState) => isUpdatingProfile,

--- a/src/app/store/tasks/tasks.actions.ts
+++ b/src/app/store/tasks/tasks.actions.ts
@@ -6,6 +6,7 @@ import {
   CodeExecutionResponse,
   SubmissionResponse,
 } from '@app/core/models/tasks-model';
+import { AppError } from '@app/core';
 
 export const loadTasks = createAction('[Tasks Dashboard] Load Tasks');
 
@@ -148,4 +149,14 @@ export const updateUserCode = createAction(
 export const restoreUserCode = createAction(
   '[Coding Assessment] Restore User Code',
   props<{ taskId: string }>(),
+);
+
+export const loadTotalUserXp = createAction('[User Xp] Load Total User Xp');
+export const loadTotalUserXpSuccess = createAction(
+  '[User Xp] Load Total User Xp Success',
+  props<{ totalUserXp: number }>(),
+);
+export const loadTotalUserXpFailure = createAction(
+  '[User Xp] Load Total Xp Failure',
+  props<{ error: AppError | null }>(),
 );

--- a/src/app/store/tasks/tasks.effects.ts
+++ b/src/app/store/tasks/tasks.effects.ts
@@ -12,7 +12,13 @@ import {
   selectCurrentTask,
   selectTimeRangeFilter,
 } from './tasks.selectors';
-import { APP_CONSTANTS, ErrorHandlerService } from '@app/core';
+import {
+  ApiResponse,
+  APP_CONSTANTS,
+  ErrorHandlerService,
+  GroupedTasksResponse,
+  Task,
+} from '@app/core';
 import { HttpErrorResponse } from '@angular/common/http';
 
 const POLLING_INTERVAL_MS = 2000;
@@ -281,11 +287,7 @@ export class TasksEffects {
       switchMap(() =>
         this.taskService.getAllTasks().pipe(
           map((response) => {
-            const totalUserXp = response.data.completed.content.reduce(
-              (sum, task) => sum + task.xpReward,
-              0,
-            );
-
+            const totalUserXp = this.calculateTotalXp(response);
             return TasksActions.loadTotalUserXpSuccess({ totalUserXp });
           }),
           catchError((httpError: HttpErrorResponse) => {
@@ -296,4 +298,11 @@ export class TasksEffects {
       ),
     ),
   );
+
+  private calculateTotalXp(response: ApiResponse<GroupedTasksResponse>): number {
+    return response.data.completed.content.reduce(
+      (sum: number, task: Task) => sum + task.xpReward,
+      0,
+    );
+  }
 }

--- a/src/app/store/tasks/tasks.effects.ts
+++ b/src/app/store/tasks/tasks.effects.ts
@@ -12,7 +12,8 @@ import {
   selectCurrentTask,
   selectTimeRangeFilter,
 } from './tasks.selectors';
-import { APP_CONSTANTS } from '@app/core';
+import { APP_CONSTANTS, ErrorHandlerService } from '@app/core';
+import { HttpErrorResponse } from '@angular/common/http';
 
 const POLLING_INTERVAL_MS = 2000;
 
@@ -24,6 +25,7 @@ export class TasksEffects {
     private router: Router,
     private toastService: ToastService,
     private store: Store,
+    private errorHandlerService: ErrorHandlerService,
   ) {}
 
   public loadTasks$ = createEffect(() =>
@@ -270,6 +272,28 @@ export class TasksEffects {
         }
         return of();
       }),
+    ),
+  );
+
+  public loadTotalUserXp$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(TasksActions.loadTotalUserXp),
+      switchMap(() =>
+        this.taskService.getAllTasks().pipe(
+          map((response) => {
+            const totalUserXp = response.data.completed.content.reduce(
+              (sum, task) => sum + task.xpReward,
+              0,
+            );
+
+            return TasksActions.loadTotalUserXpSuccess({ totalUserXp });
+          }),
+          catchError((httpError: HttpErrorResponse) => {
+            const appError = this.errorHandlerService.getError(httpError);
+            return of(TasksActions.loadTotalUserXpFailure({ error: appError }));
+          }),
+        ),
+      ),
     ),
   );
 }

--- a/src/app/store/tasks/tasks.reducer.ts
+++ b/src/app/store/tasks/tasks.reducer.ts
@@ -348,4 +348,20 @@ export const tasksReducer = createReducer(
       submissionResult: null,
     }),
   ),
+
+  on(
+    TasksActions.loadTotalUserXp,
+    (state): TasksState => ({
+      ...state,
+      isLoadingTotalUserXp: true,
+      error: null,
+    }),
+  ),
+
+  on(TasksActions.loadTotalUserXpSuccess, (state, { totalUserXp }) => ({
+    ...state,
+    totalUserXp,
+    isLoadingTotalUserXp: false,
+    error: null,
+  })),
 );

--- a/src/app/store/tasks/tasks.selectors.ts
+++ b/src/app/store/tasks/tasks.selectors.ts
@@ -150,3 +150,15 @@ export const selectSubmissionStatus = createSelector(
   selectSubmissionState,
   (state) => state.status,
 );
+
+export const selectTotalUserXp = createSelector(selectTasksState, (state) => state.totalUserXp);
+
+export const selectTotalUserXpLoading = createSelector(
+  selectTasksState,
+  (state) => state.isLoadingTotalUserXp,
+);
+
+export const selectTotalUserXpError = createSelector(
+  selectTasksState,
+  (state) => state.totalUserXpError,
+);

--- a/src/app/store/tasks/tasks.selectors.ts
+++ b/src/app/store/tasks/tasks.selectors.ts
@@ -151,14 +151,14 @@ export const selectSubmissionStatus = createSelector(
   (state) => state.status,
 );
 
-export const selectTotalUserXp = createSelector(selectTasksState, (state) => state.totalUserXp);
+export const selectTotalUserXp = createSelector(selectTasksState, ({ totalUserXp }) => totalUserXp);
 
 export const selectTotalUserXpLoading = createSelector(
   selectTasksState,
-  (state) => state.isLoadingTotalUserXp,
+  ({ isLoadingTotalUserXp }) => isLoadingTotalUserXp,
 );
 
 export const selectTotalUserXpError = createSelector(
   selectTasksState,
-  (state) => state.totalUserXpError,
+  ({ totalUserXpError }) => totalUserXpError,
 );

--- a/src/app/store/tasks/tasks.state.ts
+++ b/src/app/store/tasks/tasks.state.ts
@@ -1,3 +1,4 @@
+import { AppError } from '@app/core';
 import {
   TaskUI,
   CompletedPeriod,
@@ -40,6 +41,9 @@ export interface TasksState {
     endTime: number | null;
     taskId: string | null;
   };
+  totalUserXp: number;
+  isLoadingTotalUserXp: boolean;
+  totalUserXpError: AppError | null;
 }
 
 export const initialTasksState: TasksState = {
@@ -68,4 +72,7 @@ export const initialTasksState: TasksState = {
     endTime: null,
     taskId: null,
   },
+  totalUserXp: 0,
+  isLoadingTotalUserXp: false,
+  totalUserXpError: null,
 };


### PR DESCRIPTION
Implements NgRx state management to calculate and display total XP earned from completed tasks in the navigation header.

Changes
-------

-   ✨ Added NgRx state, actions, reducer, selectors, and effects for tasks
-   📊 Implemented XP calculation logic using `reduce()` on completed tasks
-   🎨 Updated navigation component to display total XP
-   🚀 Dashboard triggers XP load on initialization

Implementation Details
----------------------

**XP Calculation:**

```
const totalXp = response.data.completed.content.reduce(
  (sum, task) => sum + task.xpReward,
  0
);

```

**State Flow:**

1.  Dashboard loads → dispatches `loadTotalUserXp` action
2.  Effect calls `tasksService.getAllTasks()`
3.  Effect calculates total XP from completed tasks
4.  Success action updates store
5.  Navigation component displays XP via selector

Files Changed
-------------

-   `tasks.state.ts` - Tasks state interface
-   `tasks.actions.ts` - NgRx actions
-   `tasks.reducer.ts` - State reducer
-   `tasks.selectors.ts` - State selectors
-   `tasks.effects.ts` - Side effects with XP logic
-   `navigation.component.ts` - XP display
-   `dashboard.component.ts` - Action dispatch
-   `app.config.ts` - Store configuration

Testing
-------

-   [x] XP displays correctly with completed tasks
-   [x] Shows 0 when no completed tasks
-   [x] Error handling works for API failures
-   [x] Loading state managed properly
-   [x] No console errors
<img width="1920" height="983" alt="Screenshot 2025-11-23 at 2 28 59 PM" src="https://github.com/user-attachments/assets/7b2f500c-6020-4945-b8c1-1a613d19d070" />

