### PR TITLE
fix(GSDT 582): display right label and correct xp calculation

### DIFF
--- a/src/app/features/dashboard/components/dashboard-progress-overview-component/dashboard-progress-overview-component.html
+++ b/src/app/features/dashboard/components/dashboard-progress-overview-component/dashboard-progress-overview-component.html
@@ -58,7 +58,7 @@
     @if (primarySkillProgress; as firstSkill) {
       <app-progress-bar
         [currentXp]="firstSkill.currentXp"
-        [totalXp]="firstSkill.currentLevelTotalXp"
+        [totalXp]="firstSkill.xpToNextLevel"
         [levelName]="firstSkill?.nextLevel ?? ''"
       />
     } @else {

--- a/src/app/features/dashboard/dashboard.ts
+++ b/src/app/features/dashboard/dashboard.ts
@@ -13,7 +13,7 @@ import { Store } from '@ngrx/store';
 import { LucideAngularModule } from 'lucide-angular';
 
 import { getSteps as defaultSteps, defaultStepOptions } from './dashboard.config';
-import { TrajectoryGranularity } from '@app/core';
+import { SkillTrajectoryData, TrajectoryGranularity } from '@app/core';
 import { loadTotalUserXp } from '@app/store/tasks';
 
 import { AppState } from '@app/store/app.state';
@@ -76,12 +76,29 @@ export class Dashboard implements OnInit, AfterViewInit {
 
   public progressChartData = computed(() => {
     const apiData = this.trajectoryData();
+    const period = this.selectedPeriod();
 
+    switch (period) {
+      case TrajectoryGranularity.DAILY:
+        return this.generateDailyData(apiData);
+
+      case TrajectoryGranularity.WEEKLY:
+        return this.generateWeeklyData(apiData);
+
+      case TrajectoryGranularity.MONTHLY:
+        return this.generateMonthlyData(apiData);
+
+      default:
+        return [];
+    }
+  });
+
+  private generateDailyData(apiData: SkillTrajectoryData[]) {
     const startOfWeek = this.getMonday(new Date());
 
-    return Array.from({ length: 7 }).map((_, i) => {
+    return Array.from({ length: 7 }).map((_, index) => {
       const date = new Date(startOfWeek);
-      date.setDate(startOfWeek.getDate() + i);
+      date.setDate(startOfWeek.getDate() + index);
 
       const found = apiData?.find(
         (d) => new Date(d.snapshotDate).toDateString() === date.toDateString(),
@@ -92,7 +109,73 @@ export class Dashboard implements OnInit, AfterViewInit {
         value: found ? found.averageXpEarned : 0,
       };
     });
-  });
+  }
+
+  private getWeekOfMonth(date: Date): number {
+    const firstDay = new Date(date.getFullYear(), date.getMonth(), 1);
+    const dayOfWeek = firstDay.getDay() || 7;
+
+    return Math.ceil((date.getDate() + dayOfWeek - 1) / 7);
+  }
+
+  private generateWeeklyData(apiData: SkillTrajectoryData[]) {
+    const today = new Date();
+    const year = today.getFullYear();
+    const month = today.getMonth();
+
+    const weeks = [1, 2, 3, 4, 5];
+
+    return weeks.map((week) => {
+      const matchingItems = apiData?.filter((d) => {
+        const dDate = new Date(d.snapshotDate);
+        return (
+          dDate.getFullYear() === year &&
+          dDate.getMonth() === month &&
+          this.getWeekOfMonth(dDate) === week
+        );
+      });
+
+      const totalXp = matchingItems.reduce((sum, item) => sum + item.averageXpEarned, 0);
+
+      return {
+        label: `Week ${week}`,
+        value: totalXp || 0,
+      };
+    });
+  }
+
+  private generateMonthlyData(apiData: SkillTrajectoryData[]) {
+    const year = new Date().getFullYear();
+
+    const monthLabels = [
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec',
+    ];
+
+    return monthLabels.map((label, monthIndex) => {
+      const matchingItems = apiData?.filter((d) => {
+        const dDate = new Date(d.snapshotDate);
+        return dDate.getFullYear() === year && dDate.getMonth() === monthIndex;
+      });
+
+      const totalXp = matchingItems.reduce((sum, item) => sum + item.averageXpEarned, 0);
+
+      return {
+        label,
+        value: totalXp || 0,
+      };
+    });
+  }
 
   private getMonday(date: Date) {
     const d = new Date(date);

--- a/src/app/shared/components/progress-bar/progress-bar.html
+++ b/src/app/shared/components/progress-bar/progress-bar.html
@@ -9,7 +9,9 @@
     <div class="progress-bar-track">
       <div class="progress-bar-fill" [style.width.%]="progressPercent()"></div>
     </div>
-    <span class="progress-ratio"> {{ currentXp | number }}XP / {{ totalXp | number }}XP </span>
+    <span class="progress-ratio">
+      {{ currentXp | number }}XP / {{ currentXp + totalXp | number }}XP
+    </span>
   </div>
 
   <div class="progress-footer">

--- a/src/app/shared/components/progress-bar/progress-bar.spec.ts
+++ b/src/app/shared/components/progress-bar/progress-bar.spec.ts
@@ -45,8 +45,8 @@ describe('ProgressBar', () => {
     component.levelName = 'Level 5';
     fixture.detectChanges();
 
-    expect(component.progressPercent()).toBe(50);
-    expect(component.xpNeeded()).toBe(50);
+    expect(component.progressPercent()).toBe(33.33333333333333);
+    expect(component.xpNeeded()).toBe(100);
 
     const titleEl = fixture.debugElement.query(By.css('.progress-title')).nativeElement;
     const ratioEl = fixture.debugElement.query(By.css('.progress-ratio')).nativeElement;
@@ -54,9 +54,9 @@ describe('ProgressBar', () => {
     const fillEl = fixture.debugElement.query(By.css('.progress-bar-fill')).nativeElement;
 
     expect(titleEl.textContent).toContain('Progress to Level 5');
-    expect(ratioEl.textContent).toContain('50XP / 100XP');
-    expect(footerEl.textContent).toContain('50 XP needed');
-    expect(fillEl.style.width).toBe('50%');
+    expect(ratioEl.textContent).toContain('50XP / 150XP');
+    expect(footerEl.textContent).toContain('100 XP needed to proceed to the next level');
+    expect(fillEl.style.width).toBe('33.33333333333333%');
   });
 
   it('should handle large numbers and format them with commas', () => {
@@ -64,16 +64,16 @@ describe('ProgressBar', () => {
     component.totalXp = 5000;
     fixture.detectChanges();
 
-    expect(component.progressPercent()).toBe(25);
-    expect(component.xpNeeded()).toBe(3750);
+    expect(component.progressPercent()).toBe(20);
+    expect(component.xpNeeded()).toBe(5000);
 
     const ratioEl = fixture.debugElement.query(By.css('.progress-ratio')).nativeElement;
     const footerEl = fixture.debugElement.query(By.css('.progress-footer span')).nativeElement;
     const fillEl = fixture.debugElement.query(By.css('.progress-bar-fill')).nativeElement;
 
-    expect(ratioEl.textContent).toContain('1,250XP / 5,000XP');
-    expect(footerEl.textContent).toContain('3,750 XP needed to proceed to the next level');
-    expect(fillEl.style.width).toBe('25%');
+    expect(ratioEl.textContent).toContain('1,250XP / 6,250XP');
+    expect(footerEl.textContent).toContain('5,000 XP needed to proceed to the next level');
+    expect(fillEl.style.width).toBe('20%');
   });
 
   it('should handle division by zero safely', () => {

--- a/src/app/shared/components/progress-bar/progress-bar.ts
+++ b/src/app/shared/components/progress-bar/progress-bar.ts
@@ -15,10 +15,10 @@ export class ProgressBar {
 
   public progressPercent: Signal<number> = computed(() => {
     if (this.totalXp === 0) return 0;
-    return (this.currentXp / this.totalXp) * 100;
+    return (this.currentXp / (this.currentXp + this.totalXp)) * 100;
   });
 
   public xpNeeded: Signal<number> = computed(() => {
-    return this.totalXp - this.currentXp;
+    return this.totalXp;
   });
 }


### PR DESCRIPTION
This PR updates the graph to display the right label for daily, weekly, and monthly. It also corrects the xp calculation for moving to the next level.

<img width="1590" height="873" alt="Screenshot 2025-11-30 at 4 40 16 PM" src="https://github.com/user-attachments/assets/77ccd53b-3038-4177-b83f-36f4170b24a4" />
