### PR TITLE
fix(GSDT 587): dynamic progress bar

### DIFF
--- a/src/app/features/tasks-dashboard/tasks-dashboard.ts
+++ b/src/app/features/tasks-dashboard/tasks-dashboard.ts
@@ -18,6 +18,7 @@ import {
   startTask,
   changeTodayTasksPage,
   changePreviousTasksPage,
+  loadTotalUserXp,
 } from '@app/store/tasks/tasks.actions';
 import { TaskList } from './components/task-list/task-list';
 import {
@@ -51,6 +52,7 @@ export class TasksDashboard implements OnInit {
   public ngOnInit(): void {
     this.store.dispatch(loadTasks());
     this.store.dispatch(loadUserSkills());
+    this.store.dispatch(loadTotalUserXp());
   }
 
   public onSkillChange(skill: string): void {

--- a/src/app/shared/components/dashboard-sidebar/dashboard-sidebar.html
+++ b/src/app/shared/components/dashboard-sidebar/dashboard-sidebar.html
@@ -31,7 +31,11 @@
         Premium
       </h2>
       <p>Unlock AI coaching, advanced analytics, and unlimited practice tasks</p>
-      <button type="button" aria-label="Get Started with Premium to unlock more features">
+      <button
+        (click)="startFreeTrial()"
+        type="button"
+        aria-label="Get Started with Premium to unlock more features"
+      >
         Start Free Trial
       </button>
     </div>

--- a/src/app/shared/components/dashboard-sidebar/dashboard-sidebar.ts
+++ b/src/app/shared/components/dashboard-sidebar/dashboard-sidebar.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
-import { RouterLink, RouterLinkActive } from '@angular/router';
+import { RouterLink, RouterLinkActive, Router } from '@angular/router';
 import { LucideAngularModule } from 'lucide-angular';
 
 import { Store } from '@ngrx/store';
@@ -7,6 +7,7 @@ import { AppState } from '@app/store';
 import { logout } from '@app/store/auth/auth.actions';
 import { selectIsLoggingOut } from '@app/store/auth/auth.selectors';
 import { AppIcon } from '../app-icon/app-icon';
+import { APP_CONSTANTS } from '@app/core';
 
 interface MenuItem {
   icon: string;
@@ -14,6 +15,8 @@ interface MenuItem {
   route: string;
   tourId: string;
 }
+
+const { FULL_PAGE_ROUTES } = APP_CONSTANTS;
 
 @Component({
   selector: 'app-dashboard-sidebar',
@@ -31,7 +34,10 @@ export class DashboardSidebar {
 
   public isSubmitting = this.store.selectSignal(selectIsLoggingOut);
 
-  constructor(private store: Store<AppState>) {}
+  constructor(
+    private store: Store<AppState>,
+    private router: Router,
+  ) {}
 
   public onNavigate(): void {
     this.navigated.emit();
@@ -44,5 +50,9 @@ export class DashboardSidebar {
 
   public getRouterLinkOptions(route: string): { exact: boolean } {
     return { exact: route !== '/dashboard/tasks' };
+  }
+
+  public startFreeTrial() {
+    this.router.navigateByUrl(`${FULL_PAGE_ROUTES.PLAN_CONFIRMATION}/2`);
   }
 }

--- a/src/app/shared/components/progress-bar/progress-bar.html
+++ b/src/app/shared/components/progress-bar/progress-bar.html
@@ -15,6 +15,6 @@
   </div>
 
   <div class="progress-footer">
-    <span>{{ xpNeeded() | number }} XP needed to proceed to the next level</span>
+    <span>{{ totalXp | number }} XP needed to proceed to the next level</span>
   </div>
 </div>

--- a/src/app/shared/components/progress-bar/progress-bar.spec.ts
+++ b/src/app/shared/components/progress-bar/progress-bar.spec.ts
@@ -26,7 +26,7 @@ describe('ProgressBar', () => {
     fixture.detectChanges();
 
     expect(component.progressPercent()).toBe(0);
-    expect(component.xpNeeded()).toBe(100);
+    expect(component.totalXp).toBe(100);
 
     const titleEl = fixture.debugElement.query(By.css('.progress-title')).nativeElement;
     const ratioEl = fixture.debugElement.query(By.css('.progress-ratio')).nativeElement;
@@ -46,7 +46,7 @@ describe('ProgressBar', () => {
     fixture.detectChanges();
 
     expect(component.progressPercent()).toBe(33.33333333333333);
-    expect(component.xpNeeded()).toBe(100);
+    expect(component.totalXp).toBe(100);
 
     const titleEl = fixture.debugElement.query(By.css('.progress-title')).nativeElement;
     const ratioEl = fixture.debugElement.query(By.css('.progress-ratio')).nativeElement;
@@ -65,7 +65,7 @@ describe('ProgressBar', () => {
     fixture.detectChanges();
 
     expect(component.progressPercent()).toBe(20);
-    expect(component.xpNeeded()).toBe(5000);
+    expect(component.totalXp).toBe(5000);
 
     const ratioEl = fixture.debugElement.query(By.css('.progress-ratio')).nativeElement;
     const footerEl = fixture.debugElement.query(By.css('.progress-footer span')).nativeElement;
@@ -82,7 +82,7 @@ describe('ProgressBar', () => {
     fixture.detectChanges();
 
     expect(component.progressPercent()).toBe(0);
-    expect(component.xpNeeded()).toBe(0);
+    expect(component.totalXp).toBe(0);
 
     const ratioEl = fixture.debugElement.query(By.css('.progress-ratio')).nativeElement;
     const fillEl = fixture.debugElement.query(By.css('.progress-bar-fill')).nativeElement;

--- a/src/app/shared/components/progress-bar/progress-bar.ts
+++ b/src/app/shared/components/progress-bar/progress-bar.ts
@@ -17,8 +17,4 @@ export class ProgressBar {
     if (this.totalXp === 0) return 0;
     return (this.currentXp / (this.currentXp + this.totalXp)) * 100;
   });
-
-  public xpNeeded: Signal<number> = computed(() => {
-    return this.totalXp;
-  });
 }

--- a/src/app/shared/components/progress-chart/progress-chart.ts
+++ b/src/app/shared/components/progress-chart/progress-chart.ts
@@ -66,7 +66,7 @@ export class ProgressChart implements OnChanges {
 
     return [
       {
-        name: 'XP',
+        name: 'AVERAGE XP',
         series,
       },
     ];

--- a/src/app/store/dashboard/dashboard.selectors.ts
+++ b/src/app/store/dashboard/dashboard.selectors.ts
@@ -25,11 +25,6 @@ export const selectSkillsInProgressCount = createSelector(
   (data) => data?.skillProgress?.length ?? 0,
 );
 
-export const selectPrimarySkillProgress = createSelector(
-  selectDashboardData,
-  (data) => data?.skillProgress?.[0] ?? null,
-);
-
 export const selectGoalStatus = createSelector(
   selectDashboardData,
   (data) => data?.goalStatus ?? [],
@@ -83,6 +78,19 @@ export const selectIsUserSkillsLoading = createSelector(
 export const selectSelectedSkillId = createSelector(
   selectDashboardState,
   ({ selectedSkillId }: DashboardState) => selectedSkillId,
+);
+
+export const selectPrimarySkillProgress = createSelector(
+  selectDashboardData,
+  selectSelectedSkillId,
+  (data, selectedSkillId) => {
+    const skills = data?.skillProgress ?? [];
+    if (skills.length === 0) return null;
+
+    if (!selectedSkillId) return skills[0];
+
+    return skills.find((skill) => skill.skillId === selectedSkillId) ?? null;
+  },
 );
 
 export const selectSelectedSkillName = createSelector(


### PR DESCRIPTION
This PR makes changes to the progress bar by making  data displayed dynamic based on the selected skill.

<img width="1430" height="810" alt="Screenshot 2025-12-02 at 3 56 25 AM" src="https://github.com/user-attachments/assets/1fc787cc-30ed-47ad-90f1-1826e0f0bd4f" />
